### PR TITLE
Explicit byte array types

### DIFF
--- a/cmd/gobind/doc.go
+++ b/cmd/gobind/doc.go
@@ -43,6 +43,8 @@ Supported types include:
 
 	- String and boolean types.
 
+	- Byte array types.
+	
 	- Any function type all of whose parameters and results have
 	  supported types. Functions must return either no results,
 	  one result, or two results where the type of the second is


### PR DESCRIPTION
I believe in https://github.com/golang/mobile/commit/71e2276663b98ae4634b2f9186bba50fdc1dca09 it is verified that byte arrays can indeed by passed from Java to Go.