### PR TITLE
Fix typo in bind.go (file extension check)

### DIFF
--- a/cmd/gomobile/bind.go
+++ b/cmd/gomobile/bind.go
@@ -326,7 +326,7 @@ func buildAAR(androidDir string, pkg *build.Package) (err error) {
 	if *buildO == "" {
 		*buildO = pkg.Name + ".aar"
 	}
-	if !strings.HasSuffix(*buildO, ".apk") {
+	if !strings.HasSuffix(*buildO, ".aar") {
 		return fmt.Errorf("output file name %q does not end in '.aar'", *buildO)
 	}
 	if !buildN {


### PR DESCRIPTION
I think there's a typo due to copypasta. encountered:
>  gomobile: output file name "golibraryname.aar" does not end in '.aar'