### PR TITLE
Enable gobind to work on Cgo files

### DIFF
--- a/cmd/gobind/gen.go
+++ b/cmd/gobind/gen.go
@@ -22,7 +22,9 @@ import (
 )
 
 func genPkg(pkg *build.Package) {
-	files := parseFiles(pkg.Dir, pkg.GoFiles)
+	packageFiles := pkg.GoFiles
+	packageFiles = append(packageFiles, pkg.CgoFiles...)
+	files := parseFiles(pkg.Dir, packageFiles)
 	if len(files) == 0 {
 		return // some error has been reported
 	}


### PR DESCRIPTION
Gobind only iterates on pkg.GoFiles, and thus skips Go files that import "C" (CgoFiles), so fix that.