### PR TITLE
Fixed build error due to unused variable glctx

### DIFF
--- a/app/x11.go
+++ b/app/x11.go
@@ -43,7 +43,7 @@ func main(f func(App)) {
 	runtime.LockOSThread()
 
 	var worker gl.Worker
-	glctx, worker = gl.NewContext()
+	_, worker = gl.NewContext()
 	workAvailable := worker.WorkAvailable()
 
 	C.createWindow()


### PR DESCRIPTION
Nothing fancy, just replaced glctx with a blank identifier to prevent the build error