### PR TITLE
Remove check for default gl.Texture{} to avoid panics

### DIFF
--- a/exp/gl/glutil/glimage.go
+++ b/exp/gl/glutil/glimage.go
@@ -151,9 +151,6 @@ func (img *Image) Upload() {
 // Release invalidates the Image and removes any underlying data structures.
 // The Image cannot be used after being deleted.
 func (img *Image) Release() {
-	if img.gltex == (gl.Texture{}) {
-		return
-	}
 
 	img.images.glctx.DeleteTexture(img.gltex)
 	img.gltex = gl.Texture{}


### PR DESCRIPTION
I believe I have discovered a bug with the releasing on image resources.

I am developing a mobile game using go-mobile and I have been experiencing panics when the app switches between active and out of focus.  There is handling code to release the resources but occasionally the app panics with the following error.

    panic("glutil.Images.Release called, but active *Image objects remain")

I have tracked this down to the check I to ignore default gl.Texture{}  objects.  This causes the number of activeImages to be > 0 and raise a panic.  I believe this check is redundant and wondered what the reason for its inclusion was.

My project is https://github.com/telecoda/go-teletris