### PR TITLE
misc/androidstudio: check on javaCompile to avoid exception

### DIFF
--- a/misc/androidstudio/src/main/groovy/org/golang/mobile/GobindPlugin.groovy
+++ b/misc/androidstudio/src/main/groovy/org/golang/mobile/GobindPlugin.groovy
@@ -216,9 +216,11 @@ class GomobileTask extends BindTask implements OutputFileTask {
 		}
 		def cmd = ["bind", "-i"]
 		// Add the generated R and databinding classes to the classpath.
-		def classpath = project.files(javaCompile.classpath, javaCompile.destinationDir)
-		cmd << "-classpath"
-		cmd << classpath.join(File.pathSeparator)
+		if (javaCompile) {
+			def classpath = project.files(javaCompile.classpath, javaCompile.destinationDir)
+			cmd << "-classpath"
+			cmd << classpath.join(File.pathSeparator)
+		}
 		cmd << "-o"
 		cmd << outputFile.getAbsolutePath()
 		cmd << "-target"


### PR DESCRIPTION
In commit https://git.io/vQ1gV, the classpath was delayed evaluated to
the task executions. But at Library mode, there will be exception
because the javaCompile involved is not intialized. Add check to fix it.