### PR TITLE
exp/audio/al: add windows support

### DIFF
--- a/exp/audio/al/al.go
+++ b/exp/audio/al/al.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build darwin linux
+// +build darwin linux windows
 
 // Package al provides OpenAL Soft bindings for Go.
 //

--- a/exp/audio/al/al_notandroid.go
+++ b/exp/audio/al/al_notandroid.go
@@ -2,15 +2,17 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build darwin linux,!android
+// +build darwin linux windows,!android
 
 package al
 
 /*
 #cgo darwin   CFLAGS:  -DGOOS_darwin
 #cgo linux    CFLAGS:  -DGOOS_linux
+#cgo windows  CFLAGS:  -DGOOS_windows
 #cgo darwin   LDFLAGS: -framework OpenAL
 #cgo linux    LDFLAGS: -lopenal
+#cgo windows  LDFLAGS: -lOpenAL32
 
 #ifdef GOOS_darwin
 #include <stdlib.h>
@@ -20,6 +22,12 @@ package al
 #ifdef GOOS_linux
 #include <stdlib.h>
 #include <AL/al.h>  // install on Ubuntu with: sudo apt-get install libopenal-dev
+#endif
+
+#ifdef GOOS_windows
+#include <windows.h>
+#include <stdlib.h>
+#include <AL/al.h>
 #endif
 */
 import "C"

--- a/exp/audio/al/al_notandroid.go
+++ b/exp/audio/al/al_notandroid.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build darwin linux windows,!android
+// +build darwin linux,!android windows
 
 package al
 

--- a/exp/audio/al/alc.go
+++ b/exp/audio/al/alc.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build darwin linux
+// +build darwin linux windows
 
 package al
 

--- a/exp/audio/al/alc_notandroid.go
+++ b/exp/audio/al/alc_notandroid.go
@@ -2,15 +2,17 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build darwin linux,!android
+// +build darwin linux windows,!android
 
 package al
 
 /*
 #cgo darwin   CFLAGS:  -DGOOS_darwin
 #cgo linux    CFLAGS:  -DGOOS_linux
+#cgo windows  CFLAGS:  -DGOOS_windows
 #cgo darwin   LDFLAGS: -framework OpenAL
 #cgo linux    LDFLAGS: -lopenal
+#cgo windows  LDFLAGS: -lOpenAL32
 
 #ifdef GOOS_darwin
 #include <stdlib.h>
@@ -18,6 +20,12 @@ package al
 #endif
 
 #ifdef GOOS_linux
+#include <stdlib.h>
+#include <AL/alc.h>
+#endif
+
+#ifdef GOOS_windows
+#include <windows.h>
 #include <stdlib.h>
 #include <AL/alc.h>
 #endif

--- a/exp/audio/al/alc_notandroid.go
+++ b/exp/audio/al/alc_notandroid.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build darwin linux windows,!android
+// +build darwin linux,!android windows
 
 package al
 

--- a/exp/audio/al/const.go
+++ b/exp/audio/al/const.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build darwin linux
+// +build darwin linux windows
 
 package al
 


### PR DESCRIPTION
Tested on Win64 with mingw-w64 and http://kcat.strangesoft.net/openal-binaries/openal-soft-1.18.2-bin.zip