### PR TITLE
gomobile: Start universe filename uppercase

### DIFF
--- a/cmd/gomobile/bind_iosapp.go
+++ b/cmd/gomobile/bind_iosapp.go
@@ -53,7 +53,7 @@ func goIOSBind(gobind string, pkgs []*build.Package, archs []string) error {
 	for i, pkg := range pkgs {
 		fileBases[i] = bindPrefix + strings.Title(pkg.Name)
 	}
-	fileBases[len(fileBases)-1] = "universe"
+	fileBases[len(fileBases)-1] = "Universe"
 
 	cmd = exec.Command("xcrun", "lipo", "-create")
 


### PR DESCRIPTION
Fixes golang/go#28335