### PR TITLE
bind: use property syntax for ObjC

### DIFF
--- a/bind/genobjc.go
+++ b/bind/genobjc.go
@@ -1121,8 +1121,9 @@ func (g *ObjcGen) genStructH(obj *types.TypeName, t *types.Struct) {
 		}
 		name, typ := f.Name(), g.objcFieldType(f.Type())
 		g.objcdoc(doc.Member(f.Name()))
-		g.Printf("- (%s)%s;\n", typ, objcNameReplacer(lowerFirst(name)))
-		g.Printf("- (void)set%s:(%s)v;\n", name, typ)
+
+		// properties are atomic by default so explicitly say otherwise
+		g.Printf("@property (nonatomic) %s %s;\n", typ, objcNameReplacer(lowerFirst(name)))
 	}
 
 	// exported methods

--- a/bind/testdata/doc.objc.h.golden
+++ b/bind/testdata/doc.objc.h.golden
@@ -46,23 +46,19 @@
 /**
  * SF is a field.
  */
-- (NSString*)sf;
-- (void)setSF:(NSString*)v;
+@property (nonatomic) NSString* sf;
 /**
  * Anonymous field.
  */
-- (DocS2*)s2;
-- (void)setS2:(DocS2*)v;
+@property (nonatomic) DocS2* s2;
 /**
  * Multiple fields.
  */
-- (NSString*)f1;
-- (void)setF1:(NSString*)v;
+@property (nonatomic) NSString* f1;
 /**
  * Multiple fields.
  */
-- (NSString*)f2;
-- (void)setF2:(NSString*)v;
+@property (nonatomic) NSString* f2;
 /**
  * After is another method.
  */

--- a/bind/testdata/issue10788.objc.h.golden
+++ b/bind/testdata/issue10788.objc.h.golden
@@ -25,8 +25,7 @@
 
 - (instancetype)initWithRef:(id)ref;
 - (instancetype)init;
-- (NSString*)value;
-- (void)setValue:(NSString*)v;
+@property (nonatomic) NSString* value;
 @end
 
 @class Issue10788TestInterface;

--- a/bind/testdata/issue12328.objc.h.golden
+++ b/bind/testdata/issue12328.objc.h.golden
@@ -18,8 +18,7 @@
 
 - (instancetype)initWithRef:(id)ref;
 - (instancetype)init;
-- (NSError*)err;
-- (void)setErr:(NSError*)v;
+@property (nonatomic) NSError* err;
 @end
 
 #endif

--- a/bind/testdata/structs.objc.h.golden
+++ b/bind/testdata/structs.objc.h.golden
@@ -26,10 +26,8 @@
 
 - (instancetype)initWithRef:(id)ref;
 - (instancetype)init;
-- (double)x;
-- (void)setX:(double)v;
-- (double)y;
-- (void)setY:(double)v;
+@property (nonatomic) double x;
+@property (nonatomic) double y;
 - (StructsS*)identity:(NSError**)error;
 - (double)sum;
 @end

--- a/bind/testdata/underscores.objc.h.golden
+++ b/bind/testdata/underscores.objc.h.golden
@@ -18,8 +18,7 @@
 
 - (instancetype)initWithRef:(id)ref;
 - (instancetype)init;
-- (NSString*)underscore_field;
-- (void)setUnderscore_field:(NSString*)v;
+@property (nonatomic) NSString* underscore_field;
 @end
 
 @interface Underscore_pkg : NSObject


### PR DESCRIPTION
The current header generation uses old style Objective C
getters/setters. This causes Swift to incorrectly bridge properties as
methods. Using @property lets you write goObj.str = "value" (vs
goObj.setStr("value")).