### PR TITLE
bind: always include ref.h in generated ObjC headers

### DIFF
--- a/bind/genobjc.go
+++ b/bind/genobjc.go
@@ -149,6 +149,7 @@ func (g *ObjcGen) GenH() error {
 	for _, m := range g.modules {
 		g.Printf("@import %s;\n", m)
 	}
+	g.Printf("#include \"ref.h\"\n")
 	if g.Pkg != nil {
 		g.Printf("#include \"Universe.objc.h\"\n\n")
 	}

--- a/bind/testdata/basictypes.objc.h.golden
+++ b/bind/testdata/basictypes.objc.h.golden
@@ -7,6 +7,7 @@
 #define __Basictypes_H__
 
 @import Foundation;
+#include "ref.h"
 #include "Universe.objc.h"
 
 

--- a/bind/testdata/customprefix.objc.h.golden
+++ b/bind/testdata/customprefix.objc.h.golden
@@ -7,6 +7,7 @@
 #define __Customprefix_H__
 
 @import Foundation;
+#include "ref.h"
 #include "Universe.objc.h"
 
 

--- a/bind/testdata/customprefixEX.objc.h.golden
+++ b/bind/testdata/customprefixEX.objc.h.golden
@@ -7,6 +7,7 @@
 #define __EXCustomprefix_H__
 
 @import Foundation;
+#include "ref.h"
 #include "Universe.objc.h"
 
 

--- a/bind/testdata/doc.objc.h.golden
+++ b/bind/testdata/doc.objc.h.golden
@@ -7,6 +7,7 @@
 #define __Doc_H__
 
 @import Foundation;
+#include "ref.h"
 #include "Universe.objc.h"
 
 

--- a/bind/testdata/ignore.objc.h.golden
+++ b/bind/testdata/ignore.objc.h.golden
@@ -7,6 +7,7 @@
 #define __Ignore_H__
 
 @import Foundation;
+#include "ref.h"
 #include "Universe.objc.h"
 
 

--- a/bind/testdata/interfaces.objc.h.golden
+++ b/bind/testdata/interfaces.objc.h.golden
@@ -7,6 +7,7 @@
 #define __Interfaces_H__
 
 @import Foundation;
+#include "ref.h"
 #include "Universe.objc.h"
 
 

--- a/bind/testdata/issue10788.objc.h.golden
+++ b/bind/testdata/issue10788.objc.h.golden
@@ -7,6 +7,7 @@
 #define __Issue10788_H__
 
 @import Foundation;
+#include "ref.h"
 #include "Universe.objc.h"
 
 

--- a/bind/testdata/issue12328.objc.h.golden
+++ b/bind/testdata/issue12328.objc.h.golden
@@ -7,6 +7,7 @@
 #define __Issue12328_H__
 
 @import Foundation;
+#include "ref.h"
 #include "Universe.objc.h"
 
 

--- a/bind/testdata/issue12403.objc.h.golden
+++ b/bind/testdata/issue12403.objc.h.golden
@@ -7,6 +7,7 @@
 #define __Issue12403_H__
 
 @import Foundation;
+#include "ref.h"
 #include "Universe.objc.h"
 
 

--- a/bind/testdata/issue29559.objc.h.golden
+++ b/bind/testdata/issue29559.objc.h.golden
@@ -7,6 +7,7 @@
 #define __Issue29559_H__
 
 @import Foundation;
+#include "ref.h"
 #include "Universe.objc.h"
 
 

--- a/bind/testdata/keywords.objc.h.golden
+++ b/bind/testdata/keywords.objc.h.golden
@@ -7,6 +7,7 @@
 #define __Keywords_H__
 
 @import Foundation;
+#include "ref.h"
 #include "Universe.objc.h"
 
 

--- a/bind/testdata/structs.objc.h.golden
+++ b/bind/testdata/structs.objc.h.golden
@@ -7,6 +7,7 @@
 #define __Structs_H__
 
 @import Foundation;
+#include "ref.h"
 #include "Universe.objc.h"
 
 

--- a/bind/testdata/try.objc.h.golden
+++ b/bind/testdata/try.objc.h.golden
@@ -7,6 +7,7 @@
 #define __Try_H__
 
 @import Foundation;
+#include "ref.h"
 #include "Universe.objc.h"
 
 

--- a/bind/testdata/underscores.objc.h.golden
+++ b/bind/testdata/underscores.objc.h.golden
@@ -7,6 +7,7 @@
 #define __Underscore_pkg_H__
 
 @import Foundation;
+#include "ref.h"
 #include "Universe.objc.h"
 
 

--- a/bind/testdata/universe.objc.h.golden
+++ b/bind/testdata/universe.objc.h.golden
@@ -7,6 +7,7 @@
 #define __Universe_H__
 
 @import Foundation;
+#include "ref.h"
 
 @protocol Universeerror;
 @class Universeerror;

--- a/bind/testdata/vars.objc.h.golden
+++ b/bind/testdata/vars.objc.h.golden
@@ -7,6 +7,7 @@
 #define __Vars_H__
 
 @import Foundation;
+#include "ref.h"
 #include "Universe.objc.h"
 
 


### PR DESCRIPTION
Current generated headers work because they require `ref.h` to be loaded beforehand by the bridging header. However, in some cases where the bridging header is generated by another tool (such as Bazel), the order can't be guaranteed.

Fix that by explicitly importing `ref.h` in the headers that need it.