### PR TITLE
bind: annotate all remaining ObjC types for nullability

### DIFF
--- a/bind/genobjc.go
+++ b/bind/genobjc.go
@@ -198,7 +198,7 @@ func (g *ObjcGen) GenH() error {
 		g.objcdoc(g.docs[obj.Name()].Doc())
 		switch b := obj.Type().(*types.Basic); b.Kind() {
 		case types.String, types.UntypedString:
-			g.Printf("FOUNDATION_EXPORT NSString* const %s%s;\n", g.namePrefix, obj.Name())
+			g.Printf("FOUNDATION_EXPORT NSString* _Nonnull const %s%s;\n", g.namePrefix, obj.Name())
 		default:
 			g.Printf("FOUNDATION_EXPORT const %s %s%s;\n", g.objcType(obj.Type()), g.namePrefix, obj.Name())
 		}
@@ -545,7 +545,7 @@ func (s *funcSummary) asFunc(g *ObjcGen) string {
 		skip = 1
 	}
 	for _, p := range s.retParams[skip:] {
-		params = append(params, g.objcType(p.typ)+"* "+p.name)
+		params = append(params, g.objcType(p.typ)+"* _Nullable "+p.name)
 	}
 	paramContents := "void"
 	if len(params) > 0 {
@@ -580,7 +580,7 @@ func (s *funcSummary) asSignature(g *ObjcGen) string {
 		if len(params) > 0 {
 			key = p.name
 		}
-		params = append(params, fmt.Sprintf("%s:(%s)%s", key, g.objcType(p.typ)+"*", p.name))
+		params = append(params, fmt.Sprintf("%s:(%s)%s", key, g.objcType(p.typ)+"* _Nullable", p.name))
 	}
 	return strings.Join(params, " ")
 }
@@ -878,9 +878,9 @@ func (g *ObjcGen) genInterfaceInterface(obj *types.TypeName, summary ifaceSummar
 	}
 	g.Printf(" <%s>", strings.Join(prots, ", "))
 	g.Printf(" {\n}\n")
-	g.Printf("@property(strong, readonly) id _ref;\n")
+	g.Printf("@property(strong, readonly) _Nonnull id _ref;\n")
 	g.Printf("\n")
-	g.Printf("- (instancetype)initWithRef:(id)ref;\n")
+	g.Printf("- (nonnull instancetype)initWithRef:(_Nonnull id)ref;\n")
 	for _, m := range summary.callable {
 		if !g.isSigSupported(m.Type()) {
 			g.Printf("// skipped method %s.%s with unsupported parameter or return types\n\n", obj.Name(), m.Name())
@@ -918,7 +918,7 @@ func (g *ObjcGen) genInterfaceM(obj *types.TypeName, t *types.Interface) bool {
 	g.Printf("@implementation %s%s {\n", g.namePrefix, obj.Name())
 	g.Printf("}\n")
 	g.Printf("\n")
-	g.Printf("- (instancetype)initWithRef:(id)ref {\n")
+	g.Printf("- (nonnull instancetype)initWithRef:(id)ref {\n")
 	g.Indent()
 	if isErrorType(obj.Type()) {
 		g.Printf("if (self) {\n")
@@ -1097,9 +1097,9 @@ func (g *ObjcGen) genStructH(obj *types.TypeName, t *types.Struct) {
 	}
 	g.Printf(" {\n")
 	g.Printf("}\n")
-	g.Printf("@property(strong, readonly) id _ref;\n")
+	g.Printf("@property(strong, readonly) _Nonnull id _ref;\n")
 	g.Printf("\n")
-	g.Printf("- (nonnull instancetype)initWithRef:(id)ref;\n")
+	g.Printf("- (nonnull instancetype)initWithRef:(_Nonnull id)ref;\n")
 	cons := g.constructors[obj]
 	if oinf == nil {
 		for _, f := range cons {
@@ -1156,7 +1156,7 @@ func (g *ObjcGen) genStructM(obj *types.TypeName, t *types.Struct) {
 	oinf := g.ostructs[obj]
 	g.Printf("@implementation %s%s {\n", g.namePrefix, obj.Name())
 	g.Printf("}\n\n")
-	g.Printf("- (instancetype)initWithRef:(id)ref {\n")
+	g.Printf("- (nonnull instancetype)initWithRef:(_Nonnull id)ref {\n")
 	g.Indent()
 	g.Printf("self = [super init];\n")
 	g.Printf("if (self) { __ref = ref; }\n")
@@ -1174,7 +1174,7 @@ func (g *ObjcGen) genStructM(obj *types.TypeName, t *types.Struct) {
 		}
 	}
 	if oinf != nil || len(cons) == 0 {
-		g.Printf("- (instancetype)init {\n")
+		g.Printf("- (nonnull instancetype)init {\n")
 		g.Indent()
 		g.Printf("self = [super init];\n")
 		g.Printf("if (self) {\n")

--- a/bind/testdata/basictypes.objc.h.golden
+++ b/bind/testdata/basictypes.objc.h.golden
@@ -13,9 +13,9 @@
 
 FOUNDATION_EXPORT const BOOL BasictypesABool;
 FOUNDATION_EXPORT const double BasictypesAFloat;
-FOUNDATION_EXPORT NSString* const BasictypesALongString;
+FOUNDATION_EXPORT NSString* _Nonnull const BasictypesALongString;
 FOUNDATION_EXPORT const int32_t BasictypesARune;
-FOUNDATION_EXPORT NSString* const BasictypesAString;
+FOUNDATION_EXPORT NSString* _Nonnull const BasictypesAString;
 FOUNDATION_EXPORT const int64_t BasictypesAnInt;
 FOUNDATION_EXPORT const int64_t BasictypesAnInt2;
 
@@ -23,9 +23,9 @@ FOUNDATION_EXPORT BOOL BasictypesBool(BOOL p0);
 
 FOUNDATION_EXPORT NSData* _Nullable BasictypesByteArrays(NSData* _Nullable x);
 
-FOUNDATION_EXPORT BOOL BasictypesError(NSError* _Nullable* error);
+FOUNDATION_EXPORT BOOL BasictypesError(NSError* _Nullable* _Nullable error);
 
-FOUNDATION_EXPORT BOOL BasictypesErrorPair(long* ret0_, NSError* _Nullable* error);
+FOUNDATION_EXPORT BOOL BasictypesErrorPair(long* _Nullable ret0_, NSError* _Nullable* _Nullable error);
 
 FOUNDATION_EXPORT void BasictypesInts(int8_t x, int16_t y, int32_t z, int64_t t, long u);
 

--- a/bind/testdata/basictypes.objc.m.golden
+++ b/bind/testdata/basictypes.objc.m.golden
@@ -34,7 +34,7 @@ NSData* _Nullable BasictypesByteArrays(NSData* _Nullable x) {
 	return _ret0_;
 }
 
-BOOL BasictypesError(NSError* _Nullable* error) {
+BOOL BasictypesError(NSError* _Nullable* _Nullable error) {
 	int32_t r0 = proxybasictypes__Error();
 	Universeerror* _error = nil;
 	GoSeqRef* _error_ref = go_seq_from_refnum(r0);
@@ -50,7 +50,7 @@ BOOL BasictypesError(NSError* _Nullable* error) {
 	return (_error == nil);
 }
 
-BOOL BasictypesErrorPair(long* ret0_, NSError* _Nullable* error) {
+BOOL BasictypesErrorPair(long* _Nullable ret0_, NSError* _Nullable* _Nullable error) {
 	struct proxybasictypes__ErrorPair_return res = proxybasictypes__ErrorPair();
 	long _ret0_ = (long)res.r0;
 	Universeerror* _error = nil;

--- a/bind/testdata/doc.objc.h.golden
+++ b/bind/testdata/doc.objc.h.golden
@@ -26,9 +26,9 @@
  */
 @interface DocNoDoc : NSObject <goSeqRefInterface> {
 }
-@property(strong, readonly) id _ref;
+@property(strong, readonly) _Nonnull id _ref;
 
-- (nonnull instancetype)initWithRef:(id)ref;
+- (nonnull instancetype)initWithRef:(_Nonnull id)ref;
 - (nonnull instancetype)init;
 @end
 
@@ -37,9 +37,9 @@
  */
 @interface DocS : NSObject <goSeqRefInterface> {
 }
-@property(strong, readonly) id _ref;
+@property(strong, readonly) _Nonnull id _ref;
 
-- (nonnull instancetype)initWithRef:(id)ref;
+- (nonnull instancetype)initWithRef:(_Nonnull id)ref;
 /**
  * NewS is a constructor.
  */
@@ -72,9 +72,9 @@
  */
 @interface DocS2 : NSObject <goSeqRefInterface> {
 }
-@property(strong, readonly) id _ref;
+@property(strong, readonly) _Nonnull id _ref;
 
-- (nonnull instancetype)initWithRef:(id)ref;
+- (nonnull instancetype)initWithRef:(_Nonnull id)ref;
 - (nonnull instancetype)init;
 @end
 
@@ -121,9 +121,9 @@ FOUNDATION_EXPORT DocS* _Nullable DocNewS(void);
  */
 @interface DocI : NSObject <goSeqRefInterface, DocI> {
 }
-@property(strong, readonly) id _ref;
+@property(strong, readonly) _Nonnull id _ref;
 
-- (instancetype)initWithRef:(id)ref;
+- (nonnull instancetype)initWithRef:(_Nonnull id)ref;
 /**
  * IM is a method.
  */

--- a/bind/testdata/doc.objc.m.golden
+++ b/bind/testdata/doc.objc.m.golden
@@ -12,13 +12,13 @@
 @implementation DocNoDoc {
 }
 
-- (instancetype)initWithRef:(id)ref {
+- (nonnull instancetype)initWithRef:(_Nonnull id)ref {
 	self = [super init];
 	if (self) { __ref = ref; }
 	return self;
 }
 
-- (instancetype)init {
+- (nonnull instancetype)init {
 	self = [super init];
 	if (self) {
 		__ref = go_seq_from_refnum(new_doc_NoDoc());
@@ -33,7 +33,7 @@
 @implementation DocS {
 }
 
-- (instancetype)initWithRef:(id)ref {
+- (nonnull instancetype)initWithRef:(_Nonnull id)ref {
 	self = [super init];
 	if (self) { __ref = ref; }
 	return self;
@@ -129,13 +129,13 @@
 @implementation DocS2 {
 }
 
-- (instancetype)initWithRef:(id)ref {
+- (nonnull instancetype)initWithRef:(_Nonnull id)ref {
 	self = [super init];
 	if (self) { __ref = ref; }
 	return self;
 }
 
-- (instancetype)init {
+- (nonnull instancetype)init {
 	self = [super init];
 	if (self) {
 		__ref = go_seq_from_refnum(new_doc_S2());
@@ -149,7 +149,7 @@
 @implementation DocI {
 }
 
-- (instancetype)initWithRef:(id)ref {
+- (nonnull instancetype)initWithRef:(id)ref {
 	self = [super init];
 	if (self) { __ref = ref; }
 	return self;

--- a/bind/testdata/ignore.objc.h.golden
+++ b/bind/testdata/ignore.objc.h.golden
@@ -24,9 +24,9 @@
 
 @interface IgnoreS : NSObject <goSeqRefInterface, IgnoreI> {
 }
-@property(strong, readonly) id _ref;
+@property(strong, readonly) _Nonnull id _ref;
 
-- (nonnull instancetype)initWithRef:(id)ref;
+- (nonnull instancetype)initWithRef:(_Nonnull id)ref;
 - (nonnull instancetype)init;
 // skipped field S.F with unsupported type: interface{}
 
@@ -72,9 +72,9 @@
 
 @interface IgnoreI : NSObject <goSeqRefInterface, IgnoreI> {
 }
-@property(strong, readonly) id _ref;
+@property(strong, readonly) _Nonnull id _ref;
 
-- (instancetype)initWithRef:(id)ref;
+- (nonnull instancetype)initWithRef:(_Nonnull id)ref;
 // skipped method I.Argument with unsupported parameter or return types
 
 // skipped method I.Result with unsupported parameter or return types

--- a/bind/testdata/ignore.objc.m.golden
+++ b/bind/testdata/ignore.objc.m.golden
@@ -12,13 +12,13 @@
 @implementation IgnoreS {
 }
 
-- (instancetype)initWithRef:(id)ref {
+- (nonnull instancetype)initWithRef:(_Nonnull id)ref {
 	self = [super init];
 	if (self) { __ref = ref; }
 	return self;
 }
 
-- (instancetype)init {
+- (nonnull instancetype)init {
 	self = [super init];
 	if (self) {
 		__ref = go_seq_from_refnum(new_ignore_S());
@@ -38,7 +38,7 @@
 @implementation IgnoreI {
 }
 
-- (instancetype)initWithRef:(id)ref {
+- (nonnull instancetype)initWithRef:(id)ref {
 	self = [super init];
 	if (self) { __ref = ref; }
 	return self;

--- a/bind/testdata/interfaces.objc.h.golden
+++ b/bind/testdata/interfaces.objc.h.golden
@@ -29,7 +29,7 @@
 @class InterfacesWithParam;
 
 @protocol InterfacesError <NSObject>
-- (BOOL)err:(NSError* _Nullable*)error;
+- (BOOL)err:(NSError* _Nullable* _Nullable)error;
 @end
 
 @protocol InterfacesI <NSObject>
@@ -41,9 +41,9 @@
  */
 @interface InterfacesI1 : NSObject <goSeqRefInterface> {
 }
-@property(strong, readonly) id _ref;
+@property(strong, readonly) _Nonnull id _ref;
 
-- (instancetype)initWithRef:(id)ref;
+- (nonnull instancetype)initWithRef:(_Nonnull id)ref;
 - (void)j;
 @end
 
@@ -52,9 +52,9 @@
  */
 @interface InterfacesI2 : NSObject <goSeqRefInterface> {
 }
-@property(strong, readonly) id _ref;
+@property(strong, readonly) _Nonnull id _ref;
 
-- (instancetype)initWithRef:(id)ref;
+- (nonnull instancetype)initWithRef:(_Nonnull id)ref;
 - (void)g;
 @end
 
@@ -81,7 +81,7 @@
 
 FOUNDATION_EXPORT int32_t InterfacesAdd3(id<InterfacesI> _Nullable r);
 
-FOUNDATION_EXPORT BOOL InterfacesCallErr(id<InterfacesError> _Nullable e, NSError* _Nullable* error);
+FOUNDATION_EXPORT BOOL InterfacesCallErr(id<InterfacesError> _Nullable e, NSError* _Nullable* _Nullable error);
 
 FOUNDATION_EXPORT id<InterfacesI> _Nullable InterfacesSeven(void);
 
@@ -101,17 +101,17 @@ FOUNDATION_EXPORT id<InterfacesI> _Nullable InterfacesSeven(void);
 
 @interface InterfacesError : NSObject <goSeqRefInterface, InterfacesError> {
 }
-@property(strong, readonly) id _ref;
+@property(strong, readonly) _Nonnull id _ref;
 
-- (instancetype)initWithRef:(id)ref;
-- (BOOL)err:(NSError* _Nullable*)error;
+- (nonnull instancetype)initWithRef:(_Nonnull id)ref;
+- (BOOL)err:(NSError* _Nullable* _Nullable)error;
 @end
 
 @interface InterfacesI : NSObject <goSeqRefInterface, InterfacesI> {
 }
-@property(strong, readonly) id _ref;
+@property(strong, readonly) _Nonnull id _ref;
 
-- (instancetype)initWithRef:(id)ref;
+- (nonnull instancetype)initWithRef:(_Nonnull id)ref;
 - (int32_t)rand;
 @end
 
@@ -121,9 +121,9 @@ FOUNDATION_EXPORT id<InterfacesI> _Nullable InterfacesSeven(void);
  */
 @interface InterfacesI3 : NSObject <goSeqRefInterface, InterfacesI3> {
 }
-@property(strong, readonly) id _ref;
+@property(strong, readonly) _Nonnull id _ref;
 
-- (instancetype)initWithRef:(id)ref;
+- (nonnull instancetype)initWithRef:(_Nonnull id)ref;
 - (InterfacesI1* _Nullable)f;
 @end
 
@@ -132,34 +132,34 @@ FOUNDATION_EXPORT id<InterfacesI> _Nullable InterfacesSeven(void);
  */
 @interface InterfacesInterfaces : NSObject <goSeqRefInterface, InterfacesInterfaces> {
 }
-@property(strong, readonly) id _ref;
+@property(strong, readonly) _Nonnull id _ref;
 
-- (instancetype)initWithRef:(id)ref;
+- (nonnull instancetype)initWithRef:(_Nonnull id)ref;
 - (void)someMethod;
 @end
 
 @interface InterfacesLargerI : NSObject <goSeqRefInterface, InterfacesLargerI> {
 }
-@property(strong, readonly) id _ref;
+@property(strong, readonly) _Nonnull id _ref;
 
-- (instancetype)initWithRef:(id)ref;
+- (nonnull instancetype)initWithRef:(_Nonnull id)ref;
 - (void)anotherFunc;
 - (int32_t)rand;
 @end
 
 @interface InterfacesSameI : NSObject <goSeqRefInterface, InterfacesSameI> {
 }
-@property(strong, readonly) id _ref;
+@property(strong, readonly) _Nonnull id _ref;
 
-- (instancetype)initWithRef:(id)ref;
+- (nonnull instancetype)initWithRef:(_Nonnull id)ref;
 - (int32_t)rand;
 @end
 
 @interface InterfacesWithParam : NSObject <goSeqRefInterface, InterfacesWithParam> {
 }
-@property(strong, readonly) id _ref;
+@property(strong, readonly) _Nonnull id _ref;
 
-- (instancetype)initWithRef:(id)ref;
+- (nonnull instancetype)initWithRef:(_Nonnull id)ref;
 - (void)hasParam:(BOOL)p0;
 @end
 

--- a/bind/testdata/interfaces.objc.m.golden
+++ b/bind/testdata/interfaces.objc.m.golden
@@ -11,13 +11,13 @@
 @implementation InterfacesError {
 }
 
-- (instancetype)initWithRef:(id)ref {
+- (nonnull instancetype)initWithRef:(id)ref {
 	self = [super init];
 	if (self) { __ref = ref; }
 	return self;
 }
 
-- (BOOL)err:(NSError* _Nullable*)error {
+- (BOOL)err:(NSError* _Nullable* _Nullable)error {
 	int32_t refnum = go_seq_go_to_refnum(self._ref);
 	int32_t r0 = proxyinterfaces_Error_Err(refnum);
 	Universeerror* _error = nil;
@@ -40,7 +40,7 @@
 @implementation InterfacesI {
 }
 
-- (instancetype)initWithRef:(id)ref {
+- (nonnull instancetype)initWithRef:(id)ref {
 	self = [super init];
 	if (self) { __ref = ref; }
 	return self;
@@ -59,7 +59,7 @@
 @implementation InterfacesI1 {
 }
 
-- (instancetype)initWithRef:(id)ref {
+- (nonnull instancetype)initWithRef:(id)ref {
 	self = [super init];
 	if (self) { __ref = ref; }
 	return self;
@@ -76,7 +76,7 @@
 @implementation InterfacesI2 {
 }
 
-- (instancetype)initWithRef:(id)ref {
+- (nonnull instancetype)initWithRef:(id)ref {
 	self = [super init];
 	if (self) { __ref = ref; }
 	return self;
@@ -93,7 +93,7 @@
 @implementation InterfacesI3 {
 }
 
-- (instancetype)initWithRef:(id)ref {
+- (nonnull instancetype)initWithRef:(id)ref {
 	self = [super init];
 	if (self) { __ref = ref; }
 	return self;
@@ -119,7 +119,7 @@
 @implementation InterfacesInterfaces {
 }
 
-- (instancetype)initWithRef:(id)ref {
+- (nonnull instancetype)initWithRef:(id)ref {
 	self = [super init];
 	if (self) { __ref = ref; }
 	return self;
@@ -136,7 +136,7 @@
 @implementation InterfacesLargerI {
 }
 
-- (instancetype)initWithRef:(id)ref {
+- (nonnull instancetype)initWithRef:(id)ref {
 	self = [super init];
 	if (self) { __ref = ref; }
 	return self;
@@ -160,7 +160,7 @@
 @implementation InterfacesSameI {
 }
 
-- (instancetype)initWithRef:(id)ref {
+- (nonnull instancetype)initWithRef:(id)ref {
 	self = [super init];
 	if (self) { __ref = ref; }
 	return self;
@@ -179,7 +179,7 @@
 @implementation InterfacesWithParam {
 }
 
-- (instancetype)initWithRef:(id)ref {
+- (nonnull instancetype)initWithRef:(id)ref {
 	self = [super init];
 	if (self) { __ref = ref; }
 	return self;
@@ -208,7 +208,7 @@ int32_t InterfacesAdd3(id<InterfacesI> _Nullable r) {
 	return _ret0_;
 }
 
-BOOL InterfacesCallErr(id<InterfacesError> _Nullable e, NSError* _Nullable* error) {
+BOOL InterfacesCallErr(id<InterfacesError> _Nullable e, NSError* _Nullable* _Nullable error) {
 	int32_t _e;
 	if ([e conformsToProtocol:@protocol(goSeqRefInterface)]) {
 		id<goSeqRefInterface> e_proxy = (id<goSeqRefInterface>)(e);

--- a/bind/testdata/issue10788.objc.h.golden
+++ b/bind/testdata/issue10788.objc.h.golden
@@ -22,9 +22,9 @@
 
 @interface Issue10788TestStruct : NSObject <goSeqRefInterface> {
 }
-@property(strong, readonly) id _ref;
+@property(strong, readonly) _Nonnull id _ref;
 
-- (nonnull instancetype)initWithRef:(id)ref;
+- (nonnull instancetype)initWithRef:(_Nonnull id)ref;
 - (nonnull instancetype)init;
 @property (nonatomic) NSString* _Nonnull value;
 @end
@@ -33,9 +33,9 @@
 
 @interface Issue10788TestInterface : NSObject <goSeqRefInterface, Issue10788TestInterface> {
 }
-@property(strong, readonly) id _ref;
+@property(strong, readonly) _Nonnull id _ref;
 
-- (instancetype)initWithRef:(id)ref;
+- (nonnull instancetype)initWithRef:(_Nonnull id)ref;
 - (void)doSomeWork:(Issue10788TestStruct* _Nullable)s;
 - (void)multipleUnnamedParams:(long)p0 p1:(NSString* _Nullable)p1 日本:(int64_t)日本;
 @end

--- a/bind/testdata/issue10788.objc.m.golden
+++ b/bind/testdata/issue10788.objc.m.golden
@@ -12,13 +12,13 @@
 @implementation Issue10788TestStruct {
 }
 
-- (instancetype)initWithRef:(id)ref {
+- (nonnull instancetype)initWithRef:(_Nonnull id)ref {
 	self = [super init];
 	if (self) { __ref = ref; }
 	return self;
 }
 
-- (instancetype)init {
+- (nonnull instancetype)init {
 	self = [super init];
 	if (self) {
 		__ref = go_seq_from_refnum(new_issue10788_TestStruct());
@@ -45,7 +45,7 @@
 @implementation Issue10788TestInterface {
 }
 
-- (instancetype)initWithRef:(id)ref {
+- (nonnull instancetype)initWithRef:(id)ref {
 	self = [super init];
 	if (self) { __ref = ref; }
 	return self;

--- a/bind/testdata/issue12328.objc.h.golden
+++ b/bind/testdata/issue12328.objc.h.golden
@@ -15,9 +15,9 @@
 
 @interface Issue12328T : NSObject <goSeqRefInterface> {
 }
-@property(strong, readonly) id _ref;
+@property(strong, readonly) _Nonnull id _ref;
 
-- (nonnull instancetype)initWithRef:(id)ref;
+- (nonnull instancetype)initWithRef:(_Nonnull id)ref;
 - (nonnull instancetype)init;
 @property (nonatomic) NSError* _Nullable err;
 @end

--- a/bind/testdata/issue12328.objc.m.golden
+++ b/bind/testdata/issue12328.objc.m.golden
@@ -12,13 +12,13 @@
 @implementation Issue12328T {
 }
 
-- (instancetype)initWithRef:(id)ref {
+- (nonnull instancetype)initWithRef:(_Nonnull id)ref {
 	self = [super init];
 	if (self) { __ref = ref; }
 	return self;
 }
 
-- (instancetype)init {
+- (nonnull instancetype)init {
 	self = [super init];
 	if (self) {
 		__ref = go_seq_from_refnum(new_issue12328_T());

--- a/bind/testdata/issue12403.objc.h.golden
+++ b/bind/testdata/issue12403.objc.h.golden
@@ -16,18 +16,18 @@
 
 @protocol Issue12403Parsable <NSObject>
 - (NSString* _Nonnull)fromJSON:(NSString* _Nullable)jstr;
-- (NSString* _Nonnull)toJSON:(NSError* _Nullable*)error;
+- (NSString* _Nonnull)toJSON:(NSError* _Nullable* _Nullable)error;
 @end
 
 @class Issue12403Parsable;
 
 @interface Issue12403Parsable : NSObject <goSeqRefInterface, Issue12403Parsable> {
 }
-@property(strong, readonly) id _ref;
+@property(strong, readonly) _Nonnull id _ref;
 
-- (instancetype)initWithRef:(id)ref;
+- (nonnull instancetype)initWithRef:(_Nonnull id)ref;
 - (NSString* _Nonnull)fromJSON:(NSString* _Nullable)jstr;
-- (NSString* _Nonnull)toJSON:(NSError* _Nullable*)error;
+- (NSString* _Nonnull)toJSON:(NSError* _Nullable* _Nullable)error;
 @end
 
 #endif

--- a/bind/testdata/issue12403.objc.m.golden
+++ b/bind/testdata/issue12403.objc.m.golden
@@ -11,7 +11,7 @@
 @implementation Issue12403Parsable {
 }
 
-- (instancetype)initWithRef:(id)ref {
+- (nonnull instancetype)initWithRef:(id)ref {
 	self = [super init];
 	if (self) { __ref = ref; }
 	return self;
@@ -25,7 +25,7 @@
 	return _ret0_;
 }
 
-- (NSString* _Nonnull)toJSON:(NSError* _Nullable*)error {
+- (NSString* _Nonnull)toJSON:(NSError* _Nullable* _Nullable)error {
 	int32_t refnum = go_seq_go_to_refnum(self._ref);
 	struct proxyissue12403_Parsable_ToJSON_return res = proxyissue12403_Parsable_ToJSON(refnum);
 	NSString *_ret0_ = go_seq_to_objc_string(res.r0);

--- a/bind/testdata/keywords.objc.h.golden
+++ b/bind/testdata/keywords.objc.h.golden
@@ -80,9 +80,9 @@ FOUNDATION_EXPORT void KeywordsStatic(NSString* _Nullable strictfp);
 
 @interface KeywordsKeywordCaller : NSObject <goSeqRefInterface, KeywordsKeywordCaller> {
 }
-@property(strong, readonly) id _ref;
+@property(strong, readonly) _Nonnull id _ref;
 
-- (instancetype)initWithRef:(id)ref;
+- (nonnull instancetype)initWithRef:(_Nonnull id)ref;
 - (void)abstract;
 - (void)assert;
 - (void)bool_;

--- a/bind/testdata/keywords.objc.m.golden
+++ b/bind/testdata/keywords.objc.m.golden
@@ -11,7 +11,7 @@
 @implementation KeywordsKeywordCaller {
 }
 
-- (instancetype)initWithRef:(id)ref {
+- (nonnull instancetype)initWithRef:(id)ref {
 	self = [super init];
 	if (self) { __ref = ref; }
 	return self;

--- a/bind/testdata/structs.objc.h.golden
+++ b/bind/testdata/structs.objc.h.golden
@@ -23,21 +23,21 @@
 
 @interface StructsS : NSObject <goSeqRefInterface> {
 }
-@property(strong, readonly) id _ref;
+@property(strong, readonly) _Nonnull id _ref;
 
-- (nonnull instancetype)initWithRef:(id)ref;
+- (nonnull instancetype)initWithRef:(_Nonnull id)ref;
 - (nonnull instancetype)init;
 @property (nonatomic) double x;
 @property (nonatomic) double y;
-- (StructsS* _Nullable)identity:(NSError* _Nullable*)error;
+- (StructsS* _Nullable)identity:(NSError* _Nullable* _Nullable)error;
 - (double)sum;
 @end
 
 @interface StructsS2 : NSObject <goSeqRefInterface, StructsI> {
 }
-@property(strong, readonly) id _ref;
+@property(strong, readonly) _Nonnull id _ref;
 
-- (nonnull instancetype)initWithRef:(id)ref;
+- (nonnull instancetype)initWithRef:(_Nonnull id)ref;
 - (nonnull instancetype)init;
 - (void)m;
 - (NSString* _Nonnull)string;
@@ -48,24 +48,24 @@
  */
 @interface StructsStructs : NSObject <goSeqRefInterface, StructsI> {
 }
-@property(strong, readonly) id _ref;
+@property(strong, readonly) _Nonnull id _ref;
 
-- (nonnull instancetype)initWithRef:(id)ref;
+- (nonnull instancetype)initWithRef:(_Nonnull id)ref;
 - (nonnull instancetype)init;
 - (void)m;
 @end
 
 FOUNDATION_EXPORT StructsS* _Nullable StructsIdentity(StructsS* _Nullable s);
 
-FOUNDATION_EXPORT StructsS* _Nullable StructsIdentityWithError(StructsS* _Nullable s, NSError* _Nullable* error);
+FOUNDATION_EXPORT StructsS* _Nullable StructsIdentityWithError(StructsS* _Nullable s, NSError* _Nullable* _Nullable error);
 
 @class StructsI;
 
 @interface StructsI : NSObject <goSeqRefInterface, StructsI> {
 }
-@property(strong, readonly) id _ref;
+@property(strong, readonly) _Nonnull id _ref;
 
-- (instancetype)initWithRef:(id)ref;
+- (nonnull instancetype)initWithRef:(_Nonnull id)ref;
 - (void)m;
 @end
 

--- a/bind/testdata/structs.objc.m.golden
+++ b/bind/testdata/structs.objc.m.golden
@@ -12,13 +12,13 @@
 @implementation StructsS {
 }
 
-- (instancetype)initWithRef:(id)ref {
+- (nonnull instancetype)initWithRef:(_Nonnull id)ref {
 	self = [super init];
 	if (self) { __ref = ref; }
 	return self;
 }
 
-- (instancetype)init {
+- (nonnull instancetype)init {
 	self = [super init];
 	if (self) {
 		__ref = go_seq_from_refnum(new_structs_S());
@@ -52,7 +52,7 @@
 	proxystructs_S_Y_Set(refnum, _v);
 }
 
-- (StructsS* _Nullable)identity:(NSError* _Nullable*)error {
+- (StructsS* _Nullable)identity:(NSError* _Nullable* _Nullable)error {
 	int32_t refnum = go_seq_go_to_refnum(self._ref);
 	struct proxystructs_S_Identity_return res = proxystructs_S_Identity(refnum);
 	StructsS* _ret0_ = nil;
@@ -94,13 +94,13 @@
 @implementation StructsS2 {
 }
 
-- (instancetype)initWithRef:(id)ref {
+- (nonnull instancetype)initWithRef:(_Nonnull id)ref {
 	self = [super init];
 	if (self) { __ref = ref; }
 	return self;
 }
 
-- (instancetype)init {
+- (nonnull instancetype)init {
 	self = [super init];
 	if (self) {
 		__ref = go_seq_from_refnum(new_structs_S2());
@@ -127,13 +127,13 @@
 @implementation StructsStructs {
 }
 
-- (instancetype)initWithRef:(id)ref {
+- (nonnull instancetype)initWithRef:(_Nonnull id)ref {
 	self = [super init];
 	if (self) { __ref = ref; }
 	return self;
 }
 
-- (instancetype)init {
+- (nonnull instancetype)init {
 	self = [super init];
 	if (self) {
 		__ref = go_seq_from_refnum(new_structs_Structs());
@@ -152,7 +152,7 @@
 @implementation StructsI {
 }
 
-- (instancetype)initWithRef:(id)ref {
+- (nonnull instancetype)initWithRef:(id)ref {
 	self = [super init];
 	if (self) { __ref = ref; }
 	return self;
@@ -187,7 +187,7 @@ StructsS* _Nullable StructsIdentity(StructsS* _Nullable s) {
 	return _ret0_;
 }
 
-StructsS* _Nullable StructsIdentityWithError(StructsS* _Nullable s, NSError* _Nullable* error) {
+StructsS* _Nullable StructsIdentityWithError(StructsS* _Nullable s, NSError* _Nullable* _Nullable error) {
 	int32_t _s;
 	if ([s conformsToProtocol:@protocol(goSeqRefInterface)]) {
 		id<goSeqRefInterface> s_proxy = (id<goSeqRefInterface>)(s);

--- a/bind/testdata/underscores.objc.h.golden
+++ b/bind/testdata/underscores.objc.h.golden
@@ -15,9 +15,9 @@
 
 @interface Underscore_pkgUnderscore_struct : NSObject <goSeqRefInterface> {
 }
-@property(strong, readonly) id _ref;
+@property(strong, readonly) _Nonnull id _ref;
 
-- (nonnull instancetype)initWithRef:(id)ref;
+- (nonnull instancetype)initWithRef:(_Nonnull id)ref;
 - (nonnull instancetype)init;
 @property (nonatomic) NSString* _Nonnull underscore_field;
 @end

--- a/bind/testdata/underscores.objc.m.golden
+++ b/bind/testdata/underscores.objc.m.golden
@@ -12,13 +12,13 @@
 @implementation Underscore_pkgUnderscore_struct {
 }
 
-- (instancetype)initWithRef:(id)ref {
+- (nonnull instancetype)initWithRef:(_Nonnull id)ref {
 	self = [super init];
 	if (self) { __ref = ref; }
 	return self;
 }
 
-- (instancetype)init {
+- (nonnull instancetype)init {
 	self = [super init];
 	if (self) {
 		__ref = go_seq_from_refnum(new_underscore_pkg_Underscore_struct());

--- a/bind/testdata/universe.objc.h.golden
+++ b/bind/testdata/universe.objc.h.golden
@@ -20,9 +20,9 @@
 
 @interface Universeerror : NSError <goSeqRefInterface, Universeerror> {
 }
-@property(strong, readonly) id _ref;
+@property(strong, readonly) _Nonnull id _ref;
 
-- (instancetype)initWithRef:(id)ref;
+- (nonnull instancetype)initWithRef:(_Nonnull id)ref;
 - (NSString* _Nonnull)error;
 @end
 

--- a/bind/testdata/universe.objc.m.golden
+++ b/bind/testdata/universe.objc.m.golden
@@ -11,7 +11,7 @@
 @implementation Universeerror {
 }
 
-- (instancetype)initWithRef:(id)ref {
+- (nonnull instancetype)initWithRef:(id)ref {
 	if (self) {
 		__ref = ref;
 		self = [super initWithDomain:@"go" code:1 userInfo:@{NSLocalizedDescriptionKey: [self error]}];

--- a/bind/testdata/vars.objc.h.golden
+++ b/bind/testdata/vars.objc.h.golden
@@ -20,9 +20,9 @@
 
 @interface VarsS : NSObject <goSeqRefInterface, VarsI> {
 }
-@property(strong, readonly) id _ref;
+@property(strong, readonly) _Nonnull id _ref;
 
-- (nonnull instancetype)initWithRef:(id)ref;
+- (nonnull instancetype)initWithRef:(_Nonnull id)ref;
 - (nonnull instancetype)init;
 @end
 
@@ -69,9 +69,9 @@
 
 @interface VarsI : NSObject <goSeqRefInterface, VarsI> {
 }
-@property(strong, readonly) id _ref;
+@property(strong, readonly) _Nonnull id _ref;
 
-- (instancetype)initWithRef:(id)ref;
+- (nonnull instancetype)initWithRef:(_Nonnull id)ref;
 @end
 
 #endif

--- a/bind/testdata/vars.objc.m.golden
+++ b/bind/testdata/vars.objc.m.golden
@@ -12,13 +12,13 @@
 @implementation VarsS {
 }
 
-- (instancetype)initWithRef:(id)ref {
+- (nonnull instancetype)initWithRef:(_Nonnull id)ref {
 	self = [super init];
 	if (self) { __ref = ref; }
 	return self;
 }
 
-- (instancetype)init {
+- (nonnull instancetype)init {
 	self = [super init];
 	if (self) {
 		__ref = go_seq_from_refnum(new_vars_S());
@@ -32,7 +32,7 @@
 @implementation VarsI {
 }
 
-- (instancetype)initWithRef:(id)ref {
+- (nonnull instancetype)initWithRef:(id)ref {
 	self = [super init];
 	if (self) { __ref = ref; }
 	return self;


### PR DESCRIPTION
From Xcode 10.2 onwards, these annotations are required in all interface
declarations. The behaviour can be disabled, but since we were already
annotated most types it made sense to just annotate the rest.