### PR TITLE
cmd/bind: add remaining Objc nullability specifiers

### DIFF
--- a/internal/importers/objc/objc.go
+++ b/internal/importers/objc/objc.go
@@ -861,8 +861,8 @@ func initialUpper(s string) string {
 
 func (t *Named) ObjcType() string {
 	if t.Protocol {
-		return fmt.Sprintf("id<%s>", t.Name)
+		return fmt.Sprintf("id<%s> _Nullable", t.Name)
 	} else {
-		return t.Name + " *"
+		return t.Name + " * _Nullable"
 	}
 }


### PR DESCRIPTION
The `TestObjcSeqWrappers` test is failing because there are some missing nullability specifiers:

```
mobile master❯ go test -v ./bind/objc -run TestObjcSeqWrappers                                                      
=== RUN   TestObjcSeqWrappers
--- FAIL: TestObjcSeqWrappers (5.45s)
    seq_test.go:80: tmpdir = /var/folders/cm/184j3xgn311dhh1tpm6cbmyr0000gn/T/bind-objc-seq-test-434219564
    seq_test.go:98: gomobile: darwin-arm: go build -tags aaa bbb ios -buildmode=c-archive -o /var/folders/cm/184j3xgn311dhh1tpm6cbmyr0000gn/T/gomobile-work-254743475/objcpkg-arm.a gobind failed: exit status 2
        # gobind
        In file included from /var/folders/cm/184j3xgn311dhh1tpm6cbmyr0000gn/T/gomobile-work-254743475/src/gobind/interfaces_darwin.go:5:
        In file included from /var/folders/cm/184j3xgn311dhh1tpm6cbmyr0000gn/T/gomobile-work-254743475/src/gobind/interfaces.h:8:
        /var/folders/cm/184j3xgn311dhh1tpm6cbmyr0000gn/T/gomobile-work-254743475/src/gobind/Objcpkg.objc.h:26:30: error: pointer is missing a nullability type specifier (_Nonnull, _Nullable, or _Null_unspecified) [-Werror,-Wnullability-completeness]
        /var/folders/cm/184j3xgn311dhh1tpm6cbmyr0000gn/T/gomobile-work-254743475/src/gobind/Objcpkg.objc.h:26:30: note: insert '_Nullable' if the pointer may be null
        /var/folders/cm/184j3xgn311dhh1tpm6cbmyr0000gn/T/gomobile-work-254743475/src/gobind/Objcpkg.objc.h:26:30: note: insert '_Nonnull' if the pointer should never be null
        /var/folders/cm/184j3xgn311dhh1tpm6cbmyr0000gn/T/gomobile-work-254743475/src/gobind/Objcpkg.objc.h:28:11: error: pointer is missing a nullability type specifier (_Nonnull, _Nullable, or _Null_unspecified) [-Werror,-Wnullability-completeness]
        /var/folders/cm/184j3xgn311dhh1tpm6cbmyr0000gn/T/gomobile-work-254743475/src/gobind/Objcpkg.objc.h:28:11: note: insert '_Nullable' if the pointer may be null
        /var/folders/cm/184j3xgn311dhh1tpm6cbmyr0000gn/T/gomobile-work-254743475/src/gobind/Objcpkg.objc.h:28:11: note: insert '_Nonnull' if the pointer should never be null
        /var/folders/cm/184j3xgn311dhh1tpm6cbmyr0000gn/T/gomobile-work-254743475/src/gobind/Objcpkg.objc.h:38:32: error: pointer is missing a nullability type specifier (_Nonnull, _Nullable, or _Null_unspecified) [-Werror,-Wnullability-completeness]
        /var/folders/cm/184j3xgn311dhh1tpm6cbmyr0000gn/T/gomobile-work-254743475/src/gobind/Objcpkg.objc.h:38:32: note: insert '_Nullable' if the pointer may be null
        /var/folders/cm/184j3xgn311dhh1tpm6cbmyr0000gn/T/gomobile-work-254743475/src/gobind/Objcpkg.objc.h:38:32: note: insert '_Nonnull' if the pointer should never be null
        /var/folders/cm/184j3xgn311dhh1tpm6cbmyr0000gn/T/gomobile-work-254743475/src/gobind/Objcpkg.objc.h:39:23: error: pointer is missing a nullability type specifier (_Nonnull, _Nullable, or _Null_unspecified) [-Werror,-Wnullability-completeness]
        /var/folders/cm/184j3xgn311dhh1tpm6cbmyr0000gn/T/gomobile-work-254743475/src/gobind/Objcpkg.objc.h:39:34: note: insert '_Nullable' if the pointer may be null
        /var/folders/cm/184j3xgn311dhh1tpm6cbmyr0000gn/T/gomobile-work-254743475/src/gobind/Objcpkg.objc.h:39:34: note: insert '_Nonnull' if the pointer should never be null
        /var/folders/cm/184j3xgn311dhh1tpm6cbmyr0000gn/T/gomobile-work-254743475/src/gobind/Objcpkg.objc.h:50:35: error: pointer is missing a nullability type specifier (_Nonnull, _Nullable, or _Null_unspecified) [-Werror,-Wnullability-completeness]
        /var/folders/cm/184j3xgn311dhh1tpm6cbmyr0000gn/T/gomobile-work-254743475/src/gobind/Objcpkg.objc.h:50:35: note: insert '_Nullable' if the pointer may be null
        /var/folders/cm/184j3xgn311dhh1tpm6cbmyr0000gn/T/gomobile-work-254743475/src/gobind/Objcpkg.objc.h:50:35: note: insert '_Nonnull' if the pointer should never be null
        /var/folders/cm/184j3xgn311dhh1tpm6cbmyr0000gn/T/gomobile-work-254743475/src/gobind/Objcpkg.objc.h:52:29: error: pointer is missing a nullability type specifier (_Nonnull, _Nullable, or _Null_unspecified) [-Werror,-Wnullability-completeness]
        /var/folders/cm/184j3xgn311dhh1tpm6cbmyr0000gn/T/gomobile-work-254743475/src/gobind/Objcpkg.objc.h:52:29: note: insert '_Nullable' if the pointer may be null
        /var/folders/cm/184j3xgn311dhh1tpm6cbmyr0000gn/T/gomobile-work-254743475/src/gobind/Objcpkg.objc.h:52:29: note: insert '_Nonnull' if the pointer should never be null
        /var/folders/cm/184j3xgn311dhh1tpm6cbmyr0000gn/T/gomobile-work-254743475/src/gobind/Objcpkg.objc.h:52:70: error: pointer is missing a nullability type specifier (_Nonnull, _Nullable, or _Null_unspecified) [-Werror,-Wnullability-completeness]
        /var/folders/cm/184j3xgn311dhh1tpm6cbmyr0000gn/T/gomobile-work-254743475/src/gobind/Objcpkg.objc.h:52:70: note: insert '_Nullable' if the pointer may be null
        /var/folders/cm/184j3xgn311dhh1tpm6cbmyr0000gn/T/gomobile-work-254743475/src/gobind/Objcpkg.objc.h:52:70: note: insert '_Nonnull' if the pointer should never be null
        /var/folders/cm/184j3xgn311dhh1tpm6cbmyr0000gn/T/gomobile-work-254743475/src/gobind/Objcpkg.objc.h:58:52: error: pointer is missing a nullability type specifier (_Nonnull, _Nullable, or _Null_unspecified) [-Werror,-Wnullability-completeness]
        /var/folders/cm/184j3xgn311dhh1tpm6cbmyr0000gn/T/gomobile-work-254743475/src/gobind/Objcpkg.objc.h:58:52: note: insert '_Nullable' if the pointer may be null
        /var/folders/cm/184j3xgn311dhh1tpm6cbmyr0000gn/T/gomobile-work-254743475/src/gobind/Objcpkg.objc.h:58:52: note: insert '_Nonnull' if the pointer should never be null
        /var/folders/cm/184j3xgn311dhh1tpm6cbmyr0000gn/T/gomobile-work-254743475/src/gobind/Objcpkg.objc.h:58:26: error: pointer is missing a nullability type specifier (_Nonnull, _Nullable, or _Null_unspecified) [-Werror,-Wnullability-completeness]
        /var/folders/cm/184j3xgn311dhh1tpm6cbmyr0000gn/T/gomobile-work-254743475/src/gobind/Objcpkg.objc.h:58:26: note: insert '_Nullable' if the pointer may be null
        /var/folders/cm/184j3xgn311dhh1tpm6cbmyr0000gn/T/gomobile-work-254743475/src/gobind/Objcpkg.objc.h:58:26: note: insert '_Nonnull' if the pointer should never be null
        
    seq_test.go:99: failed to run gomobile bind: exit status 1
FAIL
FAIL	golang.org/x/mobile/bind/objc	5.454s
```

I've decided to set them as `_Nullable`. Even if the implementation seems to raise an exception in case the object is `NULL` in all the cases I've checked, .e.g.:

```objc
- (NSDate * _Nullable)getSelf {
	int32_t refnum = go_seq_go_to_refnum(self._ref);
	int32_t _self = go_seq_to_refnum(self);
	int32_t r0 = proxyobjcpkg_GoNSDate_GetSelf(refnum, _self);
	NSDate* _ret0_ = nil;
	GoSeqRef* _ret0__ref = go_seq_from_refnum(r0);
	if (_ret0__ref != NULL) {
		_ret0_ = _ret0__ref.obj;
		if (_ret0_ == nil) {
			LOG_FATAL(@"unexpected NULL reference");
		}
	}
	return _ret0_;
}
```

Because there are cases where we are overriding a method in the superclass that might have different nullability specifiers, .e.g.: https://github.com/golang/mobile/blob/6621de06e1e9d52c38a8c542770bdbeac9ecfef6/bind/testdata/testpkg/objcpkg/classes.go#L65

And I haven't found an easy way to detect those.