### PR TITLE
add -trimpath build flag.

### DIFF
--- a/cmd/gomobile/bind.go
+++ b/cmd/gomobile/bind.go
@@ -60,7 +60,7 @@ classes.
 
 The -v flag provides verbose output, including the list of packages built.
 
-The build flags -a, -n, -x, -gcflags, -ldflags, -tags, and -work
+The build flags -a, -n, -x, -gcflags, -ldflags, -tags, -trimpath, and -work
 are shared with the build command. For documentation, see 'go help build'.
 `,
 }

--- a/cmd/gomobile/build.go
+++ b/cmd/gomobile/build.go
@@ -61,7 +61,7 @@ output file name depends on the package built.
 
 The -v flag provides verbose output, including the list of packages built.
 
-The build flags -a, -i, -n, -x, -gcflags, -ldflags, -tags, and -work are
+The build flags -a, -i, -n, -x, -gcflags, -ldflags, -tags, -trimpath, and -work are
 shared with the build command. For documentation, see 'go help build'.
 `,
 }
@@ -230,6 +230,7 @@ var (
 	buildGcflags    string // -gcflags
 	buildLdflags    string // -ldflags
 	buildTarget     string // -target
+	buildTrimpath   bool   // -trimpath
 	buildWork       bool   // -work
 	buildBundleID   string // -bundleid
 	buildIOSVersion string // -iosversion
@@ -247,6 +248,7 @@ func addBuildFlags(cmd *command) {
 
 	cmd.flag.BoolVar(&buildA, "a", false, "")
 	cmd.flag.BoolVar(&buildI, "i", false, "")
+	cmd.flag.BoolVar(&buildTrimpath, "trimpath", false, "")
 	cmd.flag.Var((*stringsFlag)(&ctx.BuildTags), "tags", "")
 }
 
@@ -307,6 +309,9 @@ func goCmd(subcmd string, srcs []string, env []string, args ...string) error {
 	}
 	if buildLdflags != "" {
 		cmd.Args = append(cmd.Args, "-ldflags", buildLdflags)
+	}
+	if buildTrimpath {
+		cmd.Args = append(cmd.Args, "-trimpath")
 	}
 	if buildWork {
 		cmd.Args = append(cmd.Args, "-work")

--- a/cmd/gomobile/doc.go
+++ b/cmd/gomobile/doc.go
@@ -73,7 +73,7 @@ classes.
 
 The -v flag provides verbose output, including the list of packages built.
 
-The build flags -a, -n, -x, -gcflags, -ldflags, -tags, and -work
+The build flags -a, -n, -x, -gcflags, -ldflags, -tags, -trimpath, and -work
 are shared with the build command. For documentation, see 'go help build'.
 
 
@@ -117,7 +117,7 @@ output file name depends on the package built.
 
 The -v flag provides verbose output, including the list of packages built.
 
-The build flags -a, -i, -n, -x, -gcflags, -ldflags, -tags, and -work are
+The build flags -a, -i, -n, -x, -gcflags, -ldflags, -tags, -trimpath, and -work are
 shared with the build command. For documentation, see 'go help build'.
 
 
@@ -152,7 +152,7 @@ attached mobile device.
 
 Only -target android is supported. The 'adb' tool must be on the PATH.
 
-The build flags -a, -i, -n, -x, -gcflags, -ldflags, -tags, and -work are
+The build flags -a, -i, -n, -x, -gcflags, -ldflags, -tags, -trimpath, and -work are
 shared with the build command.
 For documentation, see 'go help build'.
 

--- a/cmd/gomobile/install.go
+++ b/cmd/gomobile/install.go
@@ -23,7 +23,7 @@ attached mobile device.
 
 Only -target android is supported. The 'adb' tool must be on the PATH.
 
-The build flags -a, -i, -n, -x, -gcflags, -ldflags, -tags, and -work are
+The build flags -a, -i, -n, -x, -gcflags, -ldflags, -tags, -trimpath, and -work are
 shared with the build command.
 For documentation, see 'go help build'.
 `,


### PR DESCRIPTION
Add the "-trimpath" flag from Go 1.13.