### PR TITLE
internal/binres: update wrong URL in comment

### DIFF
--- a/internal/binres/binres.go
+++ b/internal/binres/binres.go
@@ -41,7 +41,7 @@
 //    [...node]
 //
 // Additional resources:
-// https://android.googlesource.com/platform/frameworks/base/+/master/include/androidfw/ResourceTypes.h
+// https://android.googlesource.com/platform/frameworks/base/+/master/libs/androidfw/include/androidfw/ResourceTypes.h
 // https://justanapplication.wordpress.com/2011/09/13/ (a series of articles, increment date)
 package binres
 


### PR DESCRIPTION
The URL in the comment was invalid due to a change in the repository directory structure.
That commit is this:
https://android.googlesource.com/platform/frameworks/base/+/f6113af2d6f6eebee68d3ac510fe96d38a7a39e9