### PR TITLE
Correctly find packages in module mode

### DIFF
--- a/cmd/gomobile/build.go
+++ b/cmd/gomobile/build.go
@@ -155,7 +155,7 @@ func runBuildImpl(cmd *command) (*packages.Package, error) {
 	return pkg, nil
 }
 
-var nmRE = regexp.MustCompile(`[0-9a-f]{8} t _(?:.*/vendor/)?(golang.org/x.*/[^.]*)`)
+var nmRE = regexp.MustCompile(`[0-9a-f]{8} t _?(?:.*/vendor/)?(golang.org/x.*/[^.]*)`)
 
 func extractPkgs(nm string, path string) (map[string]bool, error) {
 	if buildN {

--- a/cmd/gomobile/build.go
+++ b/cmd/gomobile/build.go
@@ -155,7 +155,7 @@ func runBuildImpl(cmd *command) (*packages.Package, error) {
 	return pkg, nil
 }
 
-var nmRE = regexp.MustCompile(`[0-9a-f]{8} t (?:.*/vendor/)?(golang.org/x.*/[^.]*)`)
+var nmRE = regexp.MustCompile(`[0-9a-f]{8} t _(?:.*/vendor/)?(golang.org/x.*/[^.]*)`)
 
 func extractPkgs(nm string, path string) (map[string]bool, error) {
 	if buildN {


### PR DESCRIPTION
I found that with modules enabled (and not using vendor) that this regexp would not pass when you think it should.
The prefix with modules is just "_" which is also present in vendor mode...
This change means it matches in both ways as expected.