### PR TITLE
Look up the new name for certs: Apple Development

### DIFF
--- a/cmd/gomobile/build_iosapp.go
+++ b/cmd/gomobile/build_iosapp.go
@@ -160,8 +160,16 @@ func detectTeamID() (string, error) {
 	)
 	pemString, err := cmd.Output()
 	if err != nil {
-		err = fmt.Errorf("failed to pull the signing certificate to determine your team ID: %v", err)
-		return "", err
+		// If no "iPhone Developer" cert is found then try the new "Apple Development".
+		cmd := exec.Command(
+			"security", "find-certificate",
+			"-c", "Apple Development", "-p",
+		)
+		pemString, err = cmd.Output()
+		if err != nil {
+			err = fmt.Errorf("failed to pull the signing certificate to determine your team ID: %v", err)
+			return "", err
+		}
 	}
 
 	block, _ := pem.Decode(pemString)


### PR DESCRIPTION
Using the latest version of Xcode (11.4.1) on macOS Catalina, the developer certificates generated by Xcode now have the name "Apple Development" instead of "iPhone Developer".
So, running the command `gomobile build -target=ios golang.org/x/mobile/example/basic` results in the following error: `failed to pull the signing certificate to determine your team ID: exit status 44`.

This fix checks for an "Apple Development" certificate if it can't find "iPhone Developer".

See [the same fix in the Fyne project](https://github.com/fyne-io/fyne/commit/f1b1e9097929679255902e0f2871c655748c5b2f) and [the issue in Xamarin](https://github.com/xamarin/xamarin-macios/issues/6486).