### PR TITLE
Preserve CGO_CFLAGS, CGO_CXXFLAGS, and CGO_LDFLAGS on iOS Builds

### DIFF
--- a/cmd/gomobile/env.go
+++ b/cmd/gomobile/env.go
@@ -161,9 +161,9 @@ func envInit() (err error) {
 			"GOARCH="+arch,
 			"CC="+clang,
 			"CXX="+clang+"++",
-			"CGO_CFLAGS="+cflags+" -arch "+archClang(arch),
-			"CGO_CXXFLAGS="+cflags+" -arch "+archClang(arch),
-			"CGO_LDFLAGS="+cflags+" -arch "+archClang(arch),
+			"CGO_CFLAGS="+cflags+" -arch "+archClang(arch)+" "+os.Getenv("CGO_CFLAGS"),
+			"CGO_CXXFLAGS="+cflags+" -arch "+archClang(arch)+" "+os.Getenv("CGO_CXXFLAGS"),
+			"CGO_LDFLAGS="+cflags+" -arch "+archClang(arch)+" "+os.Getenv("CGO_LDFLAGS"),
 			"CGO_ENABLED=1",
 		)
 		darwinEnv[arch] = env


### PR DESCRIPTION
`go mobile` compilation for IOS overwrites `CGO_CFLAGS`,
`CGO_CXXFLAGS`, and `CGO_LDFLAGS` on iOS Builds, which makes it
impossible to link go code against C libraries or pass in additional
flags for these variables.

NOTE: These flags work as expected for Android targets.

This change appends the original value of the above environment
variables to the iOS build values calculated `go mobile` which gives
the requires settings as well as the ability to add additional flags,
for example to link to additional libraries.