### PR TITLE
bind: fix Objective-C code for struct field name with uppercase prefix

### DIFF
--- a/bind/genobjc.go
+++ b/bind/genobjc.go
@@ -218,7 +218,7 @@ func (g *ObjcGen) GenH() error {
 			objcType := g.objcType(obj.Type())
 			g.objcdoc(g.docs[obj.Name()].Doc())
 			g.Printf("+ (%s) %s;\n", objcType, objcNameReplacer(lowerFirst(obj.Name())))
-			g.Printf("+ (void) set%s:(%s)v;\n", obj.Name(), objcType)
+			g.Printf("+ (void) set%s:(%s)v;\n", initialUpper(lowerFirst(obj.Name())), objcType)
 			g.Printf("\n")
 		}
 		g.Printf("@end\n\n")
@@ -345,7 +345,7 @@ func (g *ObjcGen) genVarM(o *types.Var) {
 	objcType := g.objcType(o.Type())
 
 	// setter
-	g.Printf("+ (void) set%s:(%s)v {\n", o.Name(), objcType)
+	g.Printf("+ (void) set%s:(%s)v {\n", initialUpper(lowerFirst(o.Name())), objcType)
 	g.Indent()
 	g.genWrite("v", o.Type(), modeRetained)
 	g.Printf("var_set%s_%s(_v);\n", g.pkgPrefix, o.Name())
@@ -668,7 +668,7 @@ func (g *ObjcGen) genGetter(oName string, f *types.Var) {
 func (g *ObjcGen) genSetter(oName string, f *types.Var) {
 	t := f.Type()
 
-	g.Printf("- (void)set%s:(%s)v {\n", f.Name(), g.objcType(t))
+	g.Printf("- (void)set%s:(%s)v {\n", initialUpper(lowerFirst(f.Name())), g.objcType(t))
 	g.Indent()
 	g.Printf("int32_t refnum = go_seq_go_to_refnum(self._ref);\n")
 	g.genWrite("v", f.Type(), modeRetained)


### PR DESCRIPTION
Objective-C code generated by gobind does not correct set a struct field whose name has an upper case prefix. This includes struct fields with names such as URL, ID, etc.

Consider the following Go code:

```
package example

type S struct {
        BRAVO string
}

func Test(s *S) string {
        return s.BRAVO
}
```

Generate bindings with `gomobile bind -target ios example`.

Use the following code for iOS:

```
let s = ExampleS()
s.bravo = "example"
print("result", ExampleTest(s))
```

The output is "result" rather than "result example".

The current `gobind` generates:

```
- (void)setBRAVO:(NSString* _Nonnull)v {
        int32_t refnum = go_seq_go_to_refnum(self._ref);
        nstring _v = go_seq_from_objc_string(v);
        proxyexample_S_BRAVO_Set(refnum, _v);
}
```

It should instead generate

```
- (void)setBravo:(NSString* _Nonnull)v {
        int32_t refnum = go_seq_go_to_refnum(self._ref);
        nstring _v = go_seq_from_objc_string(v);
        proxyexample_S_BRAVO_Set(refnum, _v);
}
```

This pull request fixes this for struct fields. This also makes the change for package's top level variables for consistency.

The same problem doesn't exist for Java/Android.