### PR TITLE
cmd/gomobile: fix ndkRoot for updated NDK location

### DIFF
--- a/cmd/gomobile/env_test.go
+++ b/cmd/gomobile/env_test.go
@@ -17,36 +17,37 @@ func TestNdkRoot(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	homeorig := os.Getenv("ANDROID_HOME")
-	ndkhomeorig := os.Getenv("ANDROID_NDK_HOME")
+	homeorig := os.Getenv("ANDROID_SDK_ROOT")
+	ndkhomeorig := os.Getenv("ANDROID_NDK_ROOT")
 	defer func() {
-		os.Setenv("ANDROID_HOME", homeorig)
-		os.Setenv("ANDROID_NDK_HOME", ndkhomeorig)
+		os.Setenv("ANDROID_SKD_ROOT", homeorig)
+		os.Setenv("ANDROID_NDK_ROOT", ndkhomeorig)
 		os.RemoveAll(home)
 	}()
 
-	os.Setenv("ANDROID_HOME", home)
+	os.Setenv("ANDROID_SDK_ROOT", home)
+	os.Setenv("ANDROID_NDK_ROOT", "")
 
 	if ndk, err := ndkRoot(); err == nil {
 		t.Errorf("expected error but got %q", ndk)
 	}
 
-	sdkNDK := filepath.Join(home, "ndk-bundle")
+	sdkNDK := filepath.Join(home, "ndk/21.3.6528147")
 	envNDK := filepath.Join(home, "android-ndk")
 
 	for _, dir := range []string{sdkNDK, envNDK} {
-		if err := os.Mkdir(dir, 0755); err != nil {
+		if err := os.MkdirAll(dir, 0755); err != nil {
 			t.Fatalf("couldn't mkdir %q", dir)
 		}
 	}
 
-	os.Setenv("ANDROID_NDK_HOME", envNDK)
+	os.Setenv("ANDROID_NDK_ROOT", envNDK)
 
-	if ndk, _ := ndkRoot(); ndk != sdkNDK {
-		t.Errorf("got %q want %q", ndk, sdkNDK)
+	if ndk, _ := ndkRoot(); ndk != envNDK {
+		t.Errorf("got %q want %q", ndk, envNDK)
 	}
 
-	os.Unsetenv("ANDROID_HOME")
+	os.Unsetenv("ANDROID_SDK_ROOT")
 
 	if ndk, _ := ndkRoot(); ndk != envNDK {
 		t.Errorf("got %q want %q", ndk, envNDK)
@@ -58,7 +59,7 @@ func TestNdkRoot(t *testing.T) {
 		t.Errorf("expected error but got %q", ndk)
 	}
 
-	os.Setenv("ANDROID_HOME", home)
+	os.Setenv("ANDROID_SDK_ROOT", home)
 
 	if ndk, _ := ndkRoot(); ndk != sdkNDK {
 		t.Errorf("got %q want %q", ndk, sdkNDK)


### PR DESCRIPTION
ANDROID_HOME and ANDROID_NDK_HOME are deprecated (see
https://developer.android.com/studio/command-line/variables). Replace
them with ANDROID_SDK_ROOT and ANDROID_NDK_ROOT.

Fixes #39945