### PR TITLE
x/mobile: output diagnostic messages when skipping variables and methods

### DIFF
--- a/bind/gen.go
+++ b/bind/gen.go
@@ -43,6 +43,10 @@ const (
 	modeRetained
 )
 
+type Reporter interface {
+	Message(s string)
+}
+
 func (list ErrorList) Error() string {
 	buf := new(bytes.Buffer)
 	for i, err := range list {
@@ -84,6 +88,8 @@ type Generator struct {
 	Files  []*ast.File
 	Pkg    *types.Package
 	err    ErrorList
+
+	Reporter Reporter
 
 	// fields set by init.
 	pkgName   string

--- a/bind/testdata/ignore.go.golden
+++ b/bind/testdata/ignore.go.golden
@@ -44,7 +44,9 @@ func (p *proxyignore_I) Bind_proxy_refnum__() int32 {
 }
 
 // skipped method I.Argument with unsupported parameter or result types
+
 // skipped method I.Result with unsupported parameter or result types
+
 // skipped variable C128 with unsupported type complex128
 
 // skipped variable C64 with unsupported type complex64
@@ -60,4 +62,5 @@ func (p *proxyignore_I) Bind_proxy_refnum__() int32 {
 // skipped variable Var with unsupported type interface{}
 
 // skipped function Argument with unsupported parameter or result types
+
 // skipped function Result with unsupported parameter or result types

--- a/cmd/gobind/gen.go
+++ b/cmd/gobind/gen.go
@@ -25,7 +25,7 @@ import (
 	"golang.org/x/tools/go/packages"
 )
 
-func genPkg(lang string, p *types.Package, astFiles []*ast.File, allPkg []*types.Package, classes []*java.Class, otypes []*objc.Named) {
+func genPkg(lang string, fset *token.FileSet, p *types.Package, astFiles []*ast.File, allPkg []*types.Package, classes []*java.Class, otypes []*objc.Named) {
 	fname := defaultFileName(lang, p)
 	conf := &bind.GeneratorConfig{
 		Fset:   fset,
@@ -302,8 +302,6 @@ func processErr(err error) {
 		}
 	}
 }
-
-var fset = token.NewFileSet()
 
 func writer(fname string) (w io.Writer, closer func()) {
 	if *outdir == "" {

--- a/cmd/gobind/main.go
+++ b/cmd/gobind/main.go
@@ -9,6 +9,7 @@ import (
 	"flag"
 	"fmt"
 	"go/ast"
+	"go/token"
 	"go/types"
 	"io/ioutil"
 	"log"
@@ -145,18 +146,20 @@ func run() {
 
 	typePkgs := make([]*types.Package, len(allPkg))
 	astPkgs := make([][]*ast.File, len(allPkg))
+	fSets := make([]*token.FileSet, len(allPkg))
 	for i, pkg := range allPkg {
 		// Ignore pkg.Errors. pkg.Errors can exist when Cgo is used, but this should not affect the result.
 		// See the discussion at golang/go#36547.
 		typePkgs[i] = pkg.Types
 		astPkgs[i] = pkg.Syntax
+		fSets[i] = pkg.Fset
 	}
 	for _, l := range langs {
 		for i, pkg := range typePkgs {
-			genPkg(l, pkg, astPkgs[i], typePkgs, classes, otypes)
+			genPkg(l, fSets[i], pkg, astPkgs[i], typePkgs, classes, otypes)
 		}
 		// Generate the error package and support files
-		genPkg(l, nil, nil, typePkgs, classes, otypes)
+		genPkg(l, token.NewFileSet(), nil, nil, typePkgs, classes, otypes)
 	}
 }
 

--- a/cmd/gomobile/bind_androidapp.go
+++ b/cmd/gomobile/bind_androidapp.go
@@ -29,6 +29,8 @@ func goAndroidBind(gobind string, pkgs []*packages.Package, androidArchs []strin
 		"-lang=go,java",
 		"-outdir="+tmpdir,
 	)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
 	cmd.Env = append(cmd.Env, "GOOS=android")
 	cmd.Env = append(cmd.Env, "CGO_ENABLED=1")
 	if len(buildTags) > 0 {

--- a/cmd/gomobile/bind_iosapp.go
+++ b/cmd/gomobile/bind_iosapp.go
@@ -7,6 +7,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -22,6 +23,8 @@ func goIOSBind(gobind string, pkgs []*packages.Package, archs []string) error {
 		"-lang=go,objc",
 		"-outdir="+tmpdir,
 	)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
 	cmd.Env = append(cmd.Env, "GOOS=darwin")
 	cmd.Env = append(cmd.Env, "CGO_ENABLED=1")
 	tags := append(buildTags, "ios")


### PR DESCRIPTION
This is a first try at forwarding the warnings emitted during bind code generation to the console output, so that it's easier to catch errors early.

Closes https://github.com/golang/go/issues/41937

### Known problems

 * Emits duplicate warnings for each generated language
 * There is some code duplication in the warnf methods