### PR TITLE
cmd/gomobile: remove unnecessary IsDir check

### DIFF
--- a/cmd/gomobile/bind_androidapp.go
+++ b/cmd/gomobile/bind_androidapp.go
@@ -380,7 +380,7 @@ func androidAPIPath() (string, error) {
 	var apiVer int
 	for _, fi := range fis {
 		name := fi.Name()
-		if !fi.IsDir() || !strings.HasPrefix(name, "android-") {
+		if !strings.HasPrefix(name, "android-") {
 			continue
 		}
 		n, err := strconv.Atoi(name[len("android-"):])


### PR DESCRIPTION
The check when looking for android platform is unnecessarily stringent
in that the error would be caught by the call to os.Stat, and 
it fails when the android platform folder is a symlink, 
which is the case when developing on NixOs.