### PR TITLE
Add ability to disable bitcode

### DIFF
--- a/cmd/gomobile/env.go
+++ b/cmd/gomobile/env.go
@@ -94,7 +94,7 @@ func envInit() (err error) {
 	if err != nil {
 		return err
 	}
-	if len(strings.TrimSpace(string(out))) > 0 {
+	if len(strings.TrimSpace(string(out))) > 0 && os.Getenv("DISABLE_BITCODE") == "" {
 		bitcodeEnabled = true
 	}
 


### PR DESCRIPTION
### Description

This PR adds a new `DISABLE_BITCODE` environment variable to be able to disable bitcode.

### Why 

Currently bitcode embedding is enabled by default for `go >= 1.14` and there was no way to disable it.

In our [celo-org/celo-blockchain](https://github.com/celo-org/celo-blockchain) project (written in Go) we currently need bitcode disabled because one of the dependencies is written in Rust and we've had compatibility issues with the Rust generated bitcode and recent version of Xcode.

We were good with `go 1.13` (bitcode is disabled there), but we wanted to upgrade to `go 1.14` and got the following error:
```
go build runtime/cgo: invalid flag in go:cgo_ldflag: -fembed-bitcode
```
See more in https://app.circleci.com/pipelines/github/celo-org/celo-blockchain/4999/workflows/9807228b-1b99-44f2-90f7-371bfeba9e97/jobs/46791