### PR TITLE
arm64 simulator

### DIFF
--- a/cmd/gomobile/build.go
+++ b/cmd/gomobile/build.go
@@ -228,6 +228,7 @@ var (
 	buildIOSVersion string      // -iosversion
 	buildAndroidAPI int         // -androidapi
 	buildTags       stringsFlag // -tags
+	buildSimulator  bool        // -simulator
 )
 
 func addBuildFlags(cmd *command) {
@@ -243,6 +244,7 @@ func addBuildFlags(cmd *command) {
 	cmd.flag.BoolVar(&buildI, "i", false, "")
 	cmd.flag.BoolVar(&buildTrimpath, "trimpath", false, "")
 	cmd.flag.Var(&buildTags, "tags", "")
+	cmd.flag.BoolVar(&buildSimulator, "simulator", false, "")
 }
 
 func addBuildFlagsNVXWork(cmd *command) {

--- a/cmd/gomobile/env.go
+++ b/cmd/gomobile/env.go
@@ -147,8 +147,13 @@ func envInit() (err error) {
 		var clang, cflags string
 		switch arch {
 		case "arm64":
-			clang, cflags, err = envClang("iphoneos")
-			cflags += " -miphoneos-version-min=" + buildIOSVersion
+			if buildSimulator {
+				clang, cflags, err = envClang("iphonesimulator")
+				cflags += " -mios-simulator-version-min=" + buildIOSVersion
+			} else {
+				clang, cflags, err = envClang("iphoneos")
+				cflags += " -miphoneos-version-min=" + buildIOSVersion
+			}
 		case "amd64":
 			clang, cflags, err = envClang("iphonesimulator")
 			cflags += " -mios-simulator-version-min=" + buildIOSVersion


### PR DESCRIPTION
Go Mobile currently assumes that specifying "arm64" architecture means a device build. But, with the release of Macs using the Apple Silicon ("M1") CPU, it is desirable/necessary to build for arm64 simulator as well.

I propose adding a "-simulator" flag to the command line to allow one to specify a simulator build.