### PR TITLE
example: add Swift Package Manager example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ last-change
 *.iml
 .idea
 .gradle
+.build
 
 # Android Studio build and IDE configuration files.
 example/bind/android/local.properties

--- a/example/swift-package/Makefile
+++ b/example/swift-package/Makefile
@@ -1,0 +1,17 @@
+.DEFAULT: build
+
+build: Frameworks $(wildcard Package.*) $(wildcard Sources/*/*)
+	swift build -c release
+
+.PHONY: Frameworks
+Frameworks: Frameworks/GetGo.xcframework
+
+Frameworks/%.xcframework: Makefile $(wildcard Sources/*/*.go) $(shell which gomobile)
+	mkdir -p Frameworks
+	gomobile init
+	gomobile bind -target=ios,iossimulator,macos,maccatalyst -x -o $@ ./Sources/$*
+	touch $@
+
+test: build
+	go test ./...
+	swift test

--- a/example/swift-package/Package.swift
+++ b/example/swift-package/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+	name: "GetKit",
+	products: [
+		.library(
+			name: "GetKit",
+			targets: ["GetGo"]
+		),
+	],
+	targets: [
+		.target(
+			name: "GetKit"
+		),
+		.binaryTarget(
+			name: "GetGo",
+			path: "Frameworks/GetGo.xcframework"
+		),
+		.testTarget(
+			name: "GetKitTests",
+			dependencies: ["GetKit", "GetGo"]
+		),
+	]
+)

--- a/example/swift-package/README.md
+++ b/example/swift-package/README.md
@@ -1,0 +1,13 @@
+# [gomobile](https://pkg.go.dev/golang.org/x/mobile/cmd/gomobile) + [Swift Package Manager](https://swift.org/package-manager/)
+
+Example [Go](https://golang.org/) package built into an [XCFramework](https://developer.apple.com/documentation/swift_packages/distributing_binary_frameworks_as_swift_packages) for [Swift Package Manager](https://swift.org/package-manager/), targeting iOS, macOS, and macCatalyst targets.
+
+## Requirements
+
+Go 1.16, Swift 5.3, and Xcode 11 or later.
+
+## Usage
+
+To build the XCFramework and Swift package: `make build`
+
+To test: `make test`

--- a/example/swift-package/Sources/GetGo/get.go
+++ b/example/swift-package/Sources/GetGo/get.go
@@ -1,0 +1,22 @@
+package Go
+
+import (
+	"io"
+	"net/http"
+)
+
+// Get makes an HTTP(S) GET request to url,
+// returning the resulting content or an error.
+func Get(url string) ([]byte, error) {
+	res, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	return io.ReadAll(res.Body)
+}
+
+// Version returns the version string for this package.
+func Version() string {
+	return "0.0.1"
+}

--- a/example/swift-package/Sources/GetKit/GetKit.swift
+++ b/example/swift-package/Sources/GetKit/GetKit.swift
@@ -1,0 +1,1 @@
+// Stub file so Swift Package Manager doesn’t complain

--- a/example/swift-package/Tests/GetKitTests/GetTest.swift
+++ b/example/swift-package/Tests/GetKitTests/GetTest.swift
@@ -1,0 +1,27 @@
+import XCTest
+
+@testable import GetGo
+
+class GetTests: XCTestCase {
+	func testGet() {
+		var error: NSErrorPointer = nil
+		let response = GoGet("https://golang.org/", error)
+		XCTAssertNil(error)
+		guard let response = response else {
+			XCTFail("response == nil")
+			return
+		}
+		guard let str = String(data: response, encoding: .utf8) else {
+			XCTFail("str == nil")
+			return
+		}
+		XCTAssert(str.contains("Go"))
+		XCTAssert(str.contains("an open source programming language"))
+		XCTAssert(str.contains("https://play.golang.org"))
+	}
+
+	func testVersion() {
+		let version = GoVersion()
+		XCTAssertEqual(version, "0.0.1")
+	}
+}


### PR DESCRIPTION
Add an example Swift package built with gomobile for multiple Apple
platforms (ios, iosimulator, macos, and maccatalyst).

It builds an XCFramework file which is linked as a binary dependency by
Swift Package Manager. The resulting Swift package can be imported into
an iOS, macOS, or Catalyst app and called from Swift.

It has tests written in Swift. To run the tests, run `swift test` from
the example/swift-package directory.

Depends on golang.org/cl/334689 (golang/mobile#70).
