### PR TITLE
example: updates for XCFramework and Mac Catalyst

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,16 @@ last-change
 *.apk
 *.app
 *.framework
+*.xcframework
 *.aar
 *.iml
 .idea
 .gradle
+
+# Xcode configuration files.
+*.xcworkspace
+xcuserdata
+*.entitlements
 
 # Android Studio build and IDE configuration files.
 example/bind/android/local.properties

--- a/example/bind/ios/README
+++ b/example/bind/ios/README
@@ -1,15 +1,14 @@
 1. Use gomobile bind to bind the golang.org/x/mobile/example/bind/hello package.
-   The following command will create a static framework bundle in the current
-   directory.
+   The following command will create an XCFramework in the current directory.
 
   $ gomobile bind -target=ios golang.org/x/mobile/example/bind/hello
 
 2. Open the Xcode project by double clicking on bind.xcodeproj.
    The project will not build - ViewController.m calls a function from the hello
-   package so requires the hello.framework the gomobild bind command created
+   package so requires the Hello.xcframework that gomobile bind command created
    in Step 1.
 
-3. Drag-and-drop the hello.framework from the desktop to the project navigation window.
-   This will automatically include the hello framework into the project.
+3. Drag-and-drop Hello.xcframework from the desktop to the project navigation window.
+   This will automatically include the hello.xcframework into the project.
 
 4. Build.

--- a/example/bind/ios/README
+++ b/example/bind/ios/README
@@ -9,6 +9,6 @@
    in Step 1.
 
 3. Drag-and-drop Hello.xcframework from the desktop to the project navigation window.
-   This will automatically include the hello.xcframework into the project.
+   This will automatically include the Hello.xcframework into the project.
 
 4. Build.

--- a/example/ivy/ios/README.md
+++ b/example/ivy/ios/README.md
@@ -2,11 +2,11 @@
 
 This directory contains the source code to the Ivy iOS app.
 
-To build, first create the mobile.framework out of the Go
+To build, first create the Mobile.xcframework out of the Go
 implementation of Ivy. Run:
 
 ```
-go install golang.org/x/mobile/cmd/gomobile@latest 
+go install golang.org/x/mobile/cmd/gomobile@latest
 go install golang.org/x/mobile/cmd/gobind@latest
 ```
 
@@ -17,10 +17,10 @@ mkdir work; cd work
 go mod init work
 go get -d golang.org/x/mobile/bind@latest
 go get -d robpike.io/ivy/mobile
-gomobile bind -target=ios robpike.io/ivy/mobile
+gomobile bind -target=ios,iossimulator,maccatalyst,macos robpike.io/ivy/mobile
 ```
 
-Place the mobile.framework directory in this directory, and
+Place the Mobile.xcframework directory in this directory, and
 then open ivy.xcodeproj in Xcode.
 
 You have to specify Development Team for code signing certificate in:

--- a/example/ivy/ios/ivy.xcodeproj/project.pbxproj
+++ b/example/ivy/ios/ivy.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		7DC2F7EA26DFD9870026EBED /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7DC2F7E826DFCF750026EBED /* WebKit.framework */; };
-		7DC2F7ED26DFD9890026EBED /* mobile.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B4C2833A1B98889100878964 /* mobile.framework */; };
+		7DC2F7ED26DFD9890026EBED /* Mobile.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = B4C2833A1B98889100878964 /* Mobile.xcframework */; };
 		B461D25D1B31B27700EC4870 /* tape.html in Resources */ = {isa = PBXBuildFile; fileRef = B461D25C1B31B27700EC4870 /* tape.html */; };
 		B48878331B2E714100C7CC3C /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = B488780C1B2D1C3F00C7CC3C /* AppDelegate.m */; };
 		B48878341B2E714100C7CC3C /* IvyController.m in Sources */ = {isa = PBXBuildFile; fileRef = B488780F1B2D1C3F00C7CC3C /* IvyController.m */; };
@@ -35,7 +35,7 @@
 		B48878311B2DF1B200C7CC3C /* Suggestion.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Suggestion.m; sourceTree = "<group>"; };
 		B488783B1B2F9CD500C7CC3C /* DocsController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DocsController.h; sourceTree = "<group>"; };
 		B488783C1B2F9CD500C7CC3C /* DocsController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DocsController.m; sourceTree = "<group>"; };
-		B4C2833A1B98889100878964 /* mobile.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = mobile.framework; sourceTree = "<group>"; };
+		B4C2833A1B98889100878964 /* Mobile.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = Mobile.xcframework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -43,7 +43,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7DC2F7ED26DFD9890026EBED /* mobile.framework in Frameworks */,
+				7DC2F7ED26DFD9890026EBED /* Mobile.xcframework in Frameworks */,
 				7DC2F7EA26DFD9870026EBED /* WebKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -62,7 +62,7 @@
 		B48877FB1B2D1C3F00C7CC3C = {
 			isa = PBXGroup;
 			children = (
-				B4C2833A1B98889100878964 /* mobile.framework */,
+				B4C2833A1B98889100878964 /* Mobile.xcframework */,
 				B48878061B2D1C3F00C7CC3C /* ivy */,
 				B48878051B2D1C3F00C7CC3C /* Products */,
 				7DC2F7E726DFCF740026EBED /* Frameworks */,
@@ -248,6 +248,7 @@
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
+				SUPPORTS_MACCATALYST = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALID_ARCHS = "arm64 x86_64 armv7";
 			};
@@ -296,6 +297,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SUPPORTS_MACCATALYST = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VALID_ARCHS = "arm64 x86_64 armv7";
@@ -322,8 +324,9 @@
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_NAME = ivy;
 				STRIP_STYLE = debugging;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALID_ARCHS = "arm64 armv7";
+				SUPPORTS_MACCATALYST = YES;
+				TARGETED_DEVICE_FAMILY = "1,2,6";
+				VALID_ARCHS = "arm64 x86_64 armv7";
 			};
 			name = Debug;
 		};
@@ -348,8 +351,9 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.google.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = ivy;
 				STRIP_STYLE = debugging;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALID_ARCHS = "arm64 armv7";
+				SUPPORTS_MACCATALYST = YES;
+				TARGETED_DEVICE_FAMILY = "1,2,6";
+				VALID_ARCHS = "arm64 x86_64 armv7";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
This updates examples for the changes in golang.org/cl/334689 for
.xcframework files and Mac Catalyst.

Depends on golang.org/cl/334689

https://go-review.googlesource.com/c/mobile/+/334689/28/example/bind/ios/README#1
