### PR TITLE
cmd/gomobile: fix header padding computation in apk generation

### DIFF
--- a/cmd/gomobile/writer.go
+++ b/cmd/gomobile/writer.go
@@ -115,7 +115,7 @@ func (w *Writer) create(name string) (io.Writer, error) {
 	}
 	const fileHeaderLen = 30 // + filename + extra
 	start := w.offset + fileHeaderLen + len(name)
-	extra := start % 4
+	extra := (-start) & 3
 
 	zipfw, err := w.w.CreateHeader(&zip.FileHeader{
 		Name:  name,


### PR DESCRIPTION
fix file data align to 4