### PR TITLE
Use parallel build for frameworks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,9 @@ example/bind/android/gradlew*
 example/bind/android/gradle
 example/bind/android/build
 example/bind/android/app/build
+
+vendor
+build/
+.gitignore
+cmd/gomobile/gomobile
+.vscode/launch.json

--- a/cmd/gomobile/bind.go
+++ b/cmd/gomobile/bind.go
@@ -185,12 +185,15 @@ func copyFile(dst, src string) error {
 }
 
 func writeFile(filename string, generate func(io.Writer) error) error {
+	fmt.Println("write file:", filename)
 	if buildV {
 		fmt.Fprintf(os.Stderr, "write %s\n", filename)
 	}
 
-	if errMkDirErr := mkdir(filepath.Dir(filename)); errMkDirErr != nil {
-		return errMkDirErr
+	dirToMake := filepath.Dir(filename)
+	fmt.Println("dirToMake:", dirToMake)
+	if err := mkdir(dirToMake); err != nil {
+		fmt.Println(err)
 	}
 
 	if buildN {

--- a/cmd/gomobile/bind.go
+++ b/cmd/gomobile/bind.go
@@ -189,8 +189,8 @@ func writeFile(filename string, generate func(io.Writer) error) error {
 		fmt.Fprintf(os.Stderr, "write %s\n", filename)
 	}
 
-	if err := mkdir(filepath.Dir(filename)); err != nil {
-		return err
+	if errMkDirErr := mkdir(filepath.Dir(filename)); errMkDirErr != nil {
+		return errMkDirErr
 	}
 
 	if buildN {

--- a/cmd/gomobile/bind_iosapp.go
+++ b/cmd/gomobile/bind_iosapp.go
@@ -194,7 +194,7 @@ func buildTargetArch(t targetInfo, gobindCommandPath string, pkgs []*packages.Pa
 	env := appleEnv[t.String()][:]
 	sdk := getenv(env, "DARWIN_SDK")
 
-	frameworkDir := filepath.Join(tmpdir, t.platform, sdk, title+"_"+t.arch+".framework")
+	frameworkDir := filepath.Join(tmpdir, t.platform, sdk, t.arch, title+".framework")
 
 	fileBases := make([]string, len(pkgs)+1)
 	for i, pkg := range pkgs {

--- a/cmd/gomobile/bind_iosapp.go
+++ b/cmd/gomobile/bind_iosapp.go
@@ -8,10 +8,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"text/template"
 
 	"golang.org/x/tools/go/packages"
@@ -45,181 +47,34 @@ func goAppleBind(gobind string, pkgs []*packages.Package, targets []targetInfo) 
 
 	var frameworkDirs []string
 	frameworkArchCount := map[string]int{}
-	for _, t := range targets {
-		// Catalyst support requires iOS 13+
-		v, _ := strconv.ParseFloat(buildIOSVersion, 64)
-		if t.platform == "maccatalyst" && v < 13.0 {
-			return errors.New("catalyst requires -iosversion=13 or higher")
-		}
+	targetBuildResultMutex := &sync.Mutex{}
 
-		outDir := filepath.Join(tmpdir, t.platform)
-		outSrcDir := filepath.Join(outDir, "src")
-		gobindDir := filepath.Join(outSrcDir, "gobind")
+	var waitGroup sync.WaitGroup
+	waitGroup.Add(len(targets))
 
-		// Run gobind once per platform to generate the bindings
-		cmd := exec.Command(
-			gobind,
-			"-lang=go,objc",
-			"-outdir="+outDir,
-		)
-		cmd.Env = append(cmd.Env, "GOOS="+platformOS(t.platform))
-		cmd.Env = append(cmd.Env, "CGO_ENABLED=1")
-		tags := append(buildTags[:], platformTags(t.platform)...)
-		cmd.Args = append(cmd.Args, "-tags="+strings.Join(tags, ","))
-		if bindPrefix != "" {
-			cmd.Args = append(cmd.Args, "-prefix="+bindPrefix)
-		}
-		for _, p := range pkgs {
-			cmd.Args = append(cmd.Args, p.PkgPath)
-		}
-		if err := runCmd(cmd); err != nil {
-			return err
-		}
+	for _, target := range targets {
+		go func(target targetInfo, targetBuildResultMutex *sync.Mutex) {
+			defer waitGroup.Done()
 
-		env := appleEnv[t.String()][:]
-		sdk := getenv(env, "DARWIN_SDK")
+			log.Println("start building for target", target)
 
-		frameworkDir := filepath.Join(tmpdir, t.platform, sdk, title+".framework")
-		frameworkDirs = append(frameworkDirs, frameworkDir)
-		frameworkArchCount[frameworkDir] = frameworkArchCount[frameworkDir] + 1
-
-		fileBases := make([]string, len(pkgs)+1)
-		for i, pkg := range pkgs {
-			fileBases[i] = bindPrefix + strings.Title(pkg.Name)
-		}
-		fileBases[len(fileBases)-1] = "Universe"
-
-		// Add the generated packages to GOPATH for reverse bindings.
-		gopath := fmt.Sprintf("GOPATH=%s%c%s", outDir, filepath.ListSeparator, goEnv("GOPATH"))
-		env = append(env, gopath)
-
-		if err := writeGoMod(outDir, t.platform, t.arch); err != nil {
-			return err
-		}
-
-		// Run `go mod tidy` to force to create go.sum.
-		// Without go.sum, `go build` fails as of Go 1.16.
-		if modulesUsed {
-			if err := goModTidyAt(outSrcDir, env); err != nil {
-				return err
-			}
-		}
-
-		path, err := goAppleBindArchive(name+"-"+t.platform+"-"+t.arch, env, outSrcDir)
-		if err != nil {
-			return fmt.Errorf("%s/%s: %v", t.platform, t.arch, err)
-		}
-
-		versionsDir := filepath.Join(frameworkDir, "Versions")
-		versionsADir := filepath.Join(versionsDir, "A")
-		titlePath := filepath.Join(versionsADir, title)
-		if frameworkArchCount[frameworkDir] > 1 {
-			// Not the first static lib, attach to a fat library and skip create headers
-			fatCmd := exec.Command(
-				"xcrun",
-				"lipo", path, titlePath, "-create", "-output", titlePath,
-			)
-			if err := runCmd(fatCmd); err != nil {
-				return err
-			}
-			continue
-		}
-
-		versionsAHeadersDir := filepath.Join(versionsADir, "Headers")
-		if err := mkdir(versionsAHeadersDir); err != nil {
-			return err
-		}
-		if err := symlink("A", filepath.Join(versionsDir, "Current")); err != nil {
-			return err
-		}
-		if err := symlink("Versions/Current/Headers", filepath.Join(frameworkDir, "Headers")); err != nil {
-			return err
-		}
-		if err := symlink(filepath.Join("Versions/Current", title), filepath.Join(frameworkDir, title)); err != nil {
-			return err
-		}
-
-		lipoCmd := exec.Command(
-			"xcrun",
-			"lipo", path, "-create", "-o", titlePath,
-		)
-		if err := runCmd(lipoCmd); err != nil {
-			return err
-		}
-
-		// Copy header file next to output archive.
-		var headerFiles []string
-		if len(fileBases) == 1 {
-			headerFiles = append(headerFiles, title+".h")
-			err := copyFile(
-				filepath.Join(versionsAHeadersDir, title+".h"),
-				filepath.Join(gobindDir, bindPrefix+title+".objc.h"),
-			)
+			err, frameworkDir := buildTargetArch(target, gobind, pkgs, title, name, modulesUsed)
 			if err != nil {
-				return err
+				log.Fatalf("%v", err)
+				return
 			}
-		} else {
-			for _, fileBase := range fileBases {
-				headerFiles = append(headerFiles, fileBase+".objc.h")
-				err := copyFile(
-					filepath.Join(versionsAHeadersDir, fileBase+".objc.h"),
-					filepath.Join(gobindDir, fileBase+".objc.h"),
-				)
-				if err != nil {
-					return err
-				}
-			}
-			err := copyFile(
-				filepath.Join(versionsAHeadersDir, "ref.h"),
-				filepath.Join(gobindDir, "ref.h"),
-			)
-			if err != nil {
-				return err
-			}
-			headerFiles = append(headerFiles, title+".h")
-			err = writeFile(filepath.Join(versionsAHeadersDir, title+".h"), func(w io.Writer) error {
-				return appleBindHeaderTmpl.Execute(w, map[string]interface{}{
-					"pkgs": pkgs, "title": title, "bases": fileBases,
-				})
-			})
-			if err != nil {
-				return err
-			}
-		}
 
-		if err := mkdir(filepath.Join(versionsADir, "Resources")); err != nil {
-			return err
-		}
-		if err := symlink("Versions/Current/Resources", filepath.Join(frameworkDir, "Resources")); err != nil {
-			return err
-		}
-		err = writeFile(filepath.Join(frameworkDir, "Resources", "Info.plist"), func(w io.Writer) error {
-			_, err := w.Write([]byte(appleBindInfoPlist))
-			return err
-		})
-		if err != nil {
-			return err
-		}
+			targetBuildResultMutex.Lock()
+			frameworkDirs = append(frameworkDirs, frameworkDir)
+			frameworkArchCount[frameworkDir] = frameworkArchCount[frameworkDir] + 1
+			targetBuildResultMutex.Unlock()
 
-		var mmVals = struct {
-			Module  string
-			Headers []string
-		}{
-			Module:  title,
-			Headers: headerFiles,
-		}
-		err = writeFile(filepath.Join(versionsADir, "Modules", "module.modulemap"), func(w io.Writer) error {
-			return appleModuleMapTmpl.Execute(w, mmVals)
-		})
-		if err != nil {
-			return err
-		}
-		err = symlink(filepath.Join("Versions/Current/Modules"), filepath.Join(frameworkDir, "Modules"))
-		if err != nil {
-			return err
-		}
+			log.Println("finish building for target", target)
 
+		}(target, targetBuildResultMutex)
 	}
+
+	waitGroup.Wait()
 
 	// Finally combine all frameworks to an XCFramework
 	xcframeworkArgs := []string{"-create-xcframework"}
@@ -256,6 +111,180 @@ func goAppleBindArchive(name string, env []string, gosrc string) (string, error)
 		return "", err
 	}
 	return archive, nil
+}
+
+func buildTargetArch(t targetInfo, gobindCommandPath string, pkgs []*packages.Package, title string, name string, modulesUsed bool) (err error, frameworkDir string) {
+	// Catalyst support requires iOS 13+
+	v, _ := strconv.ParseFloat(buildIOSVersion, 64)
+	if t.platform == "maccatalyst" && v < 13.0 {
+		return errors.New("catalyst requires -iosversion=13 or higher"), ""
+	}
+
+	outDir := filepath.Join(tmpdir, t.platform, t.arch) // adding arch
+	outSrcDir := filepath.Join(outDir, "src")
+	gobindDir := filepath.Join(outSrcDir, "gobind")
+
+	// Run gobind once per platform to generate the bindings
+	cmd := exec.Command(
+		gobindCommandPath,
+		"-lang=go,objc",
+		"-outdir="+outDir,
+	)
+	cmd.Env = append(cmd.Env, "GOOS="+platformOS(t.platform))
+	cmd.Env = append(cmd.Env, "CGO_ENABLED=1")
+	tags := append(buildTags[:], platformTags(t.platform)...)
+	cmd.Args = append(cmd.Args, "-tags="+strings.Join(tags, ","))
+	if bindPrefix != "" {
+		cmd.Args = append(cmd.Args, "-prefix="+bindPrefix)
+	}
+	for _, p := range pkgs {
+		cmd.Args = append(cmd.Args, p.PkgPath)
+	}
+	if err := runCmd(cmd); err != nil {
+		return err, ""
+	}
+
+	env := appleEnv[t.String()][:]
+	sdk := getenv(env, "DARWIN_SDK")
+
+	frameworkDir = filepath.Join(tmpdir, t.platform, t.arch+"_framework", sdk, title+".framework")
+
+	fileBases := make([]string, len(pkgs)+1)
+	for i, pkg := range pkgs {
+		fileBases[i] = bindPrefix + strings.Title(pkg.Name)
+	}
+	fileBases[len(fileBases)-1] = "Universe"
+
+	// Add the generated packages to GOPATH for reverse bindings.
+	gopath := fmt.Sprintf("GOPATH=%s%c%s", outDir, filepath.ListSeparator, goEnv("GOPATH"))
+	env = append(env, gopath)
+
+	if err := writeGoMod(outDir, t.platform, t.arch); err != nil {
+		return err, ""
+	}
+
+	// Run `go mod tidy` to force to create go.sum.
+	// Without go.sum, `go build` fails as of Go 1.16.
+	if modulesUsed {
+		if err := goModTidyAt(outSrcDir, env); err != nil {
+			return err, ""
+		}
+	}
+
+	path, err := goAppleBindArchive(name+"-"+t.platform+"-"+t.arch, env, outSrcDir)
+	if err != nil {
+		return fmt.Errorf("%s/%s: %v", t.platform, t.arch, err), ""
+	}
+
+	versionsDir := filepath.Join(frameworkDir, "Versions")
+	versionsADir := filepath.Join(versionsDir, "A")
+	titlePath := filepath.Join(versionsADir, title)
+	//if frameworkArchCount[frameworkDir] > 1 {
+	//	// Not the first static lib, attach to a fat library and skip create headers
+	//	fatCmd := exec.Command(
+	//		"xcrun",
+	//		"lipo", path, titlePath, "-create", "-output", titlePath,
+	//	)
+	//	if err := runCmd(fatCmd); err != nil {
+	//		return err, ""
+	//	}
+	//	continue
+	//}
+
+	versionsAHeadersDir := filepath.Join(versionsADir, "Headers")
+	if err := mkdir(versionsAHeadersDir); err != nil {
+		return err, ""
+	}
+	if err := symlink("A", filepath.Join(versionsDir, "Current")); err != nil {
+		return err, ""
+	}
+	if err := symlink("Versions/Current/Headers", filepath.Join(frameworkDir, "Headers")); err != nil {
+		return err, ""
+	}
+	if err := symlink(filepath.Join("Versions/Current", title), filepath.Join(frameworkDir, title)); err != nil {
+		return err, ""
+	}
+
+	lipoCmd := exec.Command(
+		"xcrun",
+		"lipo", path, "-create", "-o", titlePath,
+	)
+	if err := runCmd(lipoCmd); err != nil {
+		return err, ""
+	}
+
+	// Copy header file next to output archive.
+	var headerFiles []string
+	if len(fileBases) == 1 {
+		headerFiles = append(headerFiles, title+".h")
+		err := copyFile(
+			filepath.Join(versionsAHeadersDir, title+".h"),
+			filepath.Join(gobindDir, bindPrefix+title+".objc.h"),
+		)
+		if err != nil {
+			return err, ""
+		}
+	} else {
+		for _, fileBase := range fileBases {
+			headerFiles = append(headerFiles, fileBase+".objc.h")
+			err := copyFile(
+				filepath.Join(versionsAHeadersDir, fileBase+".objc.h"),
+				filepath.Join(gobindDir, fileBase+".objc.h"),
+			)
+			if err != nil {
+				return err, ""
+			}
+		}
+		err := copyFile(
+			filepath.Join(versionsAHeadersDir, "ref.h"),
+			filepath.Join(gobindDir, "ref.h"),
+		)
+		if err != nil {
+			return err, ""
+		}
+		headerFiles = append(headerFiles, title+".h")
+		err = writeFile(filepath.Join(versionsAHeadersDir, title+".h"), func(w io.Writer) error {
+			return appleBindHeaderTmpl.Execute(w, map[string]interface{}{
+				"pkgs": pkgs, "title": title, "bases": fileBases,
+			})
+		})
+		if err != nil {
+			return err, ""
+		}
+	}
+
+	if err := mkdir(filepath.Join(versionsADir, "Resources")); err != nil {
+		return err, ""
+	}
+	if err := symlink("Versions/Current/Resources", filepath.Join(frameworkDir, "Resources")); err != nil {
+		return err, ""
+	}
+	err = writeFile(filepath.Join(frameworkDir, "Resources", "Info.plist"), func(w io.Writer) error {
+		_, err := w.Write([]byte(appleBindInfoPlist))
+		return err
+	})
+	if err != nil {
+		return err, ""
+	}
+
+	var mmVals = struct {
+		Module  string
+		Headers []string
+	}{
+		Module:  title,
+		Headers: headerFiles,
+	}
+	err = writeFile(filepath.Join(versionsADir, "Modules", "module.modulemap"), func(w io.Writer) error {
+		return appleModuleMapTmpl.Execute(w, mmVals)
+	})
+	if err != nil {
+		return err, ""
+	}
+	err = symlink(filepath.Join("Versions/Current/Modules"), filepath.Join(frameworkDir, "Modules"))
+	if err != nil {
+		return err, ""
+	}
+	return err, frameworkDir
 }
 
 var appleBindHeaderTmpl = template.Must(template.New("apple.h").Parse(`

--- a/go.sum
+++ b/go.sum
@@ -36,3 +36,5 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+robpike.io/ivy v0.1.9 h1:iZN9ddmhd1Hr8MJrMZFCu6MqFiAPtoj37HAmrCzkyno=
+robpike.io/ivy v0.1.9/go.mod h1:6B/DGaft5rvYiF7MgCTiZAAvH5W7vtu0eS2BW77updo=


### PR DESCRIPTION
Currently the build for different targets and CPU architectures is sequential. Even for a small project, it usually takes about two minutes to build for `-target maccatalyst,ios,iossimulator,macos`, which is very different from our perception of build speed of Golang. 
By adopting this parallel build approach, we can save a lot of time.

Simple visualization (`gomobile bind -target maccatalyst,ios,iossimulator,macos ...`):

**Main Branch**

1. Build Mac Catalyst (amd64)
2. Build Mac Catalyst (arm64)
    - Merge into a fat binary
3. Build iOS (arm64)
4. Build iOS Simulator (amd64)
5. Build iOS Simulator (arm64)
    - Merge into a fat binary
6. Build macOS (amd64)
7. Build macOS (arm64)
    - Merge into a fat binary
8. Create xcframework

**This PR**

1. Build different architectures in parallel
2. Merge different architectures for a single target into a fat binary (this is the limitation of xcodebuild. In theory, we don't need to do so. Reference: https://developer.apple.com/forums/thread/666335?answerId=685927022#685927022)
3. Create xcframework

## Quick Benchmark

Local machine comparison with a minimal demo Golang project (on M1 Max):

```shell
# This PR
gomobile-parallel bind -target  -o   30.98s user 17.43s system 183% cpu 26.400 total

# Main branch
gomobile bind -target maccatalyst,ios,iossimulator,macos -o   25.80s user 13.17s system 38% cpu 1:42.43 total
```