### PR TITLE
cmd/gomobile: add missing latest tag to gobind

### DIFF
--- a/cmd/gomobile/init.go
+++ b/cmd/gomobile/init.go
@@ -78,7 +78,7 @@ func runInit(cmd *command) error {
 	}()
 
 	// Make sure gobind is up to date.
-	if err := goInstall([]string{"golang.org/x/mobile/cmd/gobind"}, nil); err != nil {
+	if err := goInstall([]string{"golang.org/x/mobile/cmd/gobind@latest"}, nil); err != nil {
 		return err
 	}
 

--- a/cmd/gomobile/init_test.go
+++ b/cmd/gomobile/init_test.go
@@ -175,7 +175,7 @@ var initTmpl = template.Must(template.New("output").Parse(`GOMOBILE={{.GOPATH}}/
 rm -r -f "$GOMOBILE"
 mkdir -p $GOMOBILE
 WORK={{.GOPATH}}/pkg/gomobile/work
-go install -x golang.org/x/mobile/cmd/gobind
+go install -x golang.org/x/mobile/cmd/gobind@latest
 cp $OPENAL_PATH/include/AL/al.h $GOMOBILE/include/AL/al.h
 mkdir -p $GOMOBILE/include/AL
 cp $OPENAL_PATH/include/AL/alc.h $GOMOBILE/include/AL/alc.h


### PR DESCRIPTION
Go install requires a version to be provided after the package name.
gomobile init command is updated to reflect this new requirement

Fixes golang/go#50994