### PR TITLE
bind: added pkglink flag to use gopath pkg

### DIFF
--- a/cmd/gomobile/bind.go
+++ b/cmd/gomobile/bind.go
@@ -64,6 +64,8 @@ classes.
 
 The -v flag provides verbose output, including the list of packages built.
 
+The -pkglink flag is use link to gopath pkg
+
 The build flags -a, -n, -x, -gcflags, -ldflags, -tags, -trimpath, and -work
 are shared with the build command. For documentation, see 'go help build'.
 `,
@@ -142,6 +144,7 @@ var (
 	bindJavaPkg       string // -javapkg
 	bindClasspath     string // -classpath
 	bindBootClasspath string // -bootclasspath
+	bindGoPathPkgLink bool   //-pkglink
 )
 
 func init() {
@@ -152,6 +155,7 @@ func init() {
 		"custom Objective-C name prefix. Valid only with -target=ios.")
 	cmdBind.flag.StringVar(&bindClasspath, "classpath", "", "The classpath for imported Java classes. Valid only with -target=android.")
 	cmdBind.flag.StringVar(&bindBootClasspath, "bootclasspath", "", "The bootstrap classpath for imported Java classes. Valid only with -target=android.")
+	cmdBind.flag.BoolVar(&bindGoPathPkgLink, "pkglink", true, "pkglink link gopath pkg")
 }
 
 func bootClasspath() (string, error) {

--- a/cmd/gomobile/build.go
+++ b/cmd/gomobile/build.go
@@ -337,7 +337,22 @@ func goCmdAt(at string, subcmd string, srcs []string, env []string, args ...stri
 	return runCmd(cmd)
 }
 
+func pkgSoftLink(at string) error {
+	if bindGoPathPkgLink {
+		symlink := at + "/../pkg"
+		target := goEnv("GOPATH") + "/pkg"
+		if buildV {
+			fmt.Fprintf(os.Stderr, "try to create link, %v->%v", symlink, target)
+		}
+		return os.Symlink(target, symlink)
+	}
+	return nil
+}
+
 func goModTidyAt(at string, env []string) error {
+	if err := pkgSoftLink(at); err != nil {
+		return err
+	}
 	cmd := exec.Command("go", "mod", "tidy")
 	if buildV {
 		cmd.Args = append(cmd.Args, "-v")


### PR DESCRIPTION
(cherry picked from commit 014373cb7c9856ede6ed6bb0091a1ef7fc01c623)

in bind mode, go mod tidy will use gopath pkg first. 