### PR TITLE
onLowMemory funktionality

### DIFF
--- a/app/android.go
+++ b/app/android.go
@@ -249,6 +249,8 @@ func onConfigurationChanged(activity *C.ANativeActivity) {
 
 //export onLowMemory
 func onLowMemory(activity *C.ANativeActivity) {
+	runtime.GC()
+	debug.FreeOSMemory()
 }
 
 var (

--- a/app/android.go
+++ b/app/android.go
@@ -51,7 +51,9 @@ import (
 	"os"
 	"time"
 	"unsafe"
-
+	"runtime"
+	"runtime/debug"
+	
 	"golang.org/x/mobile/app/internal/callfn"
 	"golang.org/x/mobile/event/key"
 	"golang.org/x/mobile/event/lifecycle"


### PR DESCRIPTION
I think this change (https://github.com/fyne-io/fyne/pull/2956) should be added to gomobile too, it is only 2 rows of imports and 2 rows to release memory if Android OS send onLowMemory signal ...  