### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ to install the gomobile command, build the
 [basic](https://golang.org/x/mobile/example/basic)
 and the [bind](https://golang.org/x/mobile/example/bind) example apps.
 
---
+---
 
 Contributions to Go are appreciated. See https://golang.org/doc/contribute.html.
 


### PR DESCRIPTION
Fixed a line break/seperator.
Line break/seperator is added by 3 hyphens `---` but in the previous README it was just 2 hyphens `--`
It ain't much, but it's honest work.