### PR TITLE
cmd/gomobile: filter out xcrun warnings to get path

### DIFF
--- a/cmd/gomobile/env.go
+++ b/cmd/gomobile/env.go
@@ -431,6 +431,16 @@ func ndkRoot(targets ...targetInfo) (string, error) {
 	return ndkRoot, nil
 }
 
+// Necessary to filter out warnings about missing extensions.
+func getAbsolutePath(output []byte) (path string) {
+	for _, line := range strings.Split(string(output), "\n") {
+		if strings.HasPrefix(line, "/") {
+			return line
+		}
+	}
+	return ""
+}
+
 func envClang(sdkName string) (clang, cflags string, err error) {
 	if buildN {
 		return sdkName + "-clang", "-isysroot " + sdkName, nil
@@ -440,14 +450,14 @@ func envClang(sdkName string) (clang, cflags string, err error) {
 	if err != nil {
 		return "", "", fmt.Errorf("xcrun --find: %v\n%s", err, out)
 	}
-	clang = strings.TrimSpace(string(out))
+	clang = getAbsolutePath(out)
 
 	cmd = exec.Command("xcrun", "--sdk", sdkName, "--show-sdk-path")
 	out, err = cmd.CombinedOutput()
 	if err != nil {
 		return "", "", fmt.Errorf("xcrun --show-sdk-path: %v\n%s", err, out)
 	}
-	sdk := strings.TrimSpace(string(out))
+	sdk := getAbsolutePath(out)
 	return clang, "-isysroot " + sdk, nil
 }
 


### PR DESCRIPTION
Currently some installations of Xcode and Command Line Tools cause warnings about missing extensions which break parsing of paths returned from `xcrun` that `gomobile` depends on resulting in errors like this:
```
cgo: C compiler "2022-09-07" not found: exec: "2022-09-07": executable file not found in $PATH
```
This is caused by these warnings returned on `stdout` by `xcrun`:
```
 > xcrun --find clang
2022-09-07 14:50:13.907 xcodebuild[69942:386823822] Requested but did not find extension point with identifier Xcode.IDEKit.ExtensionSentinelHostApplications for extension Xcode.DebuggerFoundation.AppExtensionHosts.watchOS of plug-in com.apple.dt.IDEWatchSupportCore
2022-09-07 14:50:13.908 xcodebuild[69942:386823822] Requested but did not find extension point with identifier Xcode.IDEKit.ExtensionPointIdentifierToBundleIdentifier for extension Xcode.DebuggerFoundation.AppExtensionToBundleIdentifierMap.watchOS of plug-in com.apple.dt.IDEWatchSupportCore
2022-09-07 14:50:14.041 xcodebuild[69942:386823822] XType: com.apple.fonts is not accessible.
2022-09-07 14:50:14.041 xcodebuild[69942:386823822] XType: XTFontStaticRegistry is enabled.
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang
```
Resulting in `gomobile` interpreting the date `2022-09-07` as Clang compiler.

Resolves: https://github.com/golang/go/issues/53316