### PR TITLE
add path for termux on android 9+/arm64

### DIFF
--- a/cmd/gomobile/env.go
+++ b/cmd/gomobile/env.go
@@ -530,6 +530,9 @@ func archNDK() string {
 				arch = "x86_64"
 				break
 			}
+			if runtime.GOOS == "android" { // termux
+				return "linux-aarch64"
+			} 
 			fallthrough
 		default:
 			panic("unsupported GOARCH: " + runtime.GOARCH)


### PR DESCRIPTION
similar change was enabling fyne to build apk on termux https://youtu.be/uGtVjf4_Ivo