### PR TITLE
cmd/gomobile: fix a compatibility issue with Xcode 15.3

### DIFF
--- a/cmd/gomobile/bind_iosapp.go
+++ b/cmd/gomobile/bind_iosapp.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/xml"
 	"errors"
 	"fmt"
 	"io"
@@ -249,8 +250,8 @@ func goAppleBind(gobind string, pkgs []*packages.Package, targets []targetInfo) 
 		}
 		err = writeFile(filepath.Join(frameworkDir, "Resources", "Info.plist"), func(w io.Writer) error {
 			infoFrameworkPlistlData := infoFrameworkPlistlData{
-				BundleID:       rfc1034Label(title),
-				ExecutableName: title,
+				BundleID:       escapePlistValue(rfc1034Label(title)),
+				ExecutableName: escapePlistValue(title),
 			}
 			infoplist := new(bytes.Buffer)
 			if err := infoFrameworkPlistTmpl.Execute(infoplist, infoFrameworkPlistlData); err != nil {
@@ -327,6 +328,12 @@ var infoFrameworkPlistTmpl = template.Must(template.New("infoFrameworkPlist").Pa
 </dict>
 </plist>
 `))
+
+func escapePlistValue(value string) string {
+	var b bytes.Buffer
+	xml.EscapeText(&b, []byte(value))
+	return b.String()
+}
 
 var appleModuleMapTmpl = template.Must(template.New("iosmmap").Parse(`framework module "{{.Module}}" {
 	header "ref.h"

--- a/cmd/gomobile/bind_iosapp.go
+++ b/cmd/gomobile/bind_iosapp.go
@@ -249,7 +249,7 @@ func goAppleBind(gobind string, pkgs []*packages.Package, targets []targetInfo) 
 		}
 		err = writeFile(filepath.Join(frameworkDir, "Resources", "Info.plist"), func(w io.Writer) error {
 			infoFrameworkPlistlData := infoFrameworkPlistlData{
-				BundleID:       title,
+				BundleID:       rfc1034Label(title),
 				ExecutableName: title,
 			}
 			infoplist := new(bytes.Buffer)


### PR DESCRIPTION
This change adds compatibility for Xcode 15.3 to "gomobile bind" for building xcframeworks.

 - New blank Info.plist in the *.framework target root
 - Add CFBundleExecutable and CFBundleIdentifier to the resource level Info.plist

Tested locally on my framework on Xcode 15.3 (fixes issue) and 15.2 (doesn't create new issues).

Would love to get some more folks to try this fix, to make sure it works broadly.

Note: I'm using the framework name as the bundleID. Some chance of collision here, but didn't want to add a required top level cmd parameter. I don't *think* a collision is a serious concern, but I'm not an apple build system expert.

To test: 
 - sync my branch
 - build go mobile: `go build` in the `cmd/gomobile` dir
 - Build your xcframework with this version of go mobile: `gomobile bind ... `
 - Launch a project using the xcframework in Xcode 15.3, and run in simulator

Fixes golang/go#66018