### PR TITLE
Fix android minsdk usage in binres

### DIFF
--- a/cmd/gomobile/build_androidapp.go
+++ b/cmd/gomobile/build_androidapp.go
@@ -25,6 +25,7 @@ import (
 )
 
 func goAndroidBuild(pkg *packages.Package, targets []targetInfo) (map[string]bool, error) {
+	binres.MinSDK = buildAndroidAPI
 	ndkRoot, err := ndkRoot(targets...)
 	if err != nil {
 		return nil, err

--- a/internal/binres/sdk.go
+++ b/internal/binres/sdk.go
@@ -13,7 +13,9 @@ import (
 )
 
 // MinSDK is the targeted sdk version for support by package binres.
-const MinSDK = 16
+var (
+	MinSDK = 16
+)
 
 func apiResources() ([]byte, error) {
 	apiResPath, err := apiResourcesPath()


### PR DESCRIPTION
Fix for an issue https://github.com/golang/go/issues/66011
andtroidapi parameter not working when using gomobile build command