### PR TITLE
internal/sdkpath: accept minor Android platform versions

### DIFF
--- a/internal/sdkpath/sdkpath.go
+++ b/internal/sdkpath/sdkpath.go
@@ -64,26 +64,46 @@ func AndroidAPIPath(api int) (string, error) {
 	}
 
 	var apiPath string
-	var apiVer int
+	var apiMajor int
+	var apiMinor int
 	for _, fi := range fis {
 		name := fi.Name()
-		if !strings.HasPrefix(name, "android-") {
-			continue
-		}
-		n, err := strconv.Atoi(name[len("android-"):])
-		if err != nil || n < api {
+		major, minor, ok := parseAndroidPlatformVersion(name)
+		if !ok || major < api {
 			continue
 		}
 		p := filepath.Join(sdkDir.Name(), name)
 		_, err = os.Stat(filepath.Join(p, "android.jar"))
-		if err == nil && apiVer < n {
+		if err == nil && (major > apiMajor || major == apiMajor && minor > apiMinor) {
 			apiPath = p
-			apiVer = n
+			apiMajor = major
+			apiMinor = minor
 		}
 	}
-	if apiVer == 0 {
+	if apiMajor == 0 {
 		return "", fmt.Errorf("failed to find android SDK platform (API level: %d) in %s",
 			api, sdkDir.Name())
 	}
 	return apiPath, nil
+}
+
+func parseAndroidPlatformVersion(name string) (major int, minor int, ok bool) {
+	version, ok := strings.CutPrefix(name, "android-")
+	if !ok {
+		return 0, 0, false
+	}
+
+	majorString, minorString, hasMinor := strings.Cut(version, ".")
+	major, err := strconv.Atoi(majorString)
+	if err != nil {
+		return 0, 0, false
+	}
+	if !hasMinor {
+		return major, 0, true
+	}
+	minor, err = strconv.Atoi(minorString)
+	if err != nil {
+		return 0, 0, false
+	}
+	return major, minor, true
 }

--- a/internal/sdkpath/sdkpath_test.go
+++ b/internal/sdkpath/sdkpath_test.go
@@ -43,6 +43,44 @@ func TestAndroidAPIPathAcceptsMajorVersionPlatforms(t *testing.T) {
 	}
 }
 
+func TestAndroidAPIPathAcceptsMixedPlatformVersions(t *testing.T) {
+	tests := []struct {
+		name      string
+		platforms []string
+		want      string
+	}{
+		{
+			name:      "minor version is newer than major-only version",
+			platforms: []string{"android-35", "android-36", "android-36.1"},
+			want:      "android-36.1",
+		},
+		{
+			name:      "higher major-only version is newer than lower minor version",
+			platforms: []string{"android-36.1", "android-37"},
+			want:      "android-37",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sdk := t.TempDir()
+			t.Setenv("ANDROID_HOME", sdk)
+			for _, name := range tt.platforms {
+				writeAndroidPlatform(t, sdk, name)
+			}
+
+			got, err := AndroidAPIPath(24)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := filepath.Join(sdk, "platforms", tt.want)
+			if got != want {
+				t.Fatalf("AndroidAPIPath(24) = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
 func writeAndroidPlatform(t *testing.T, sdk, name string) {
 	t.Helper()
 

--- a/internal/sdkpath/sdkpath_test.go
+++ b/internal/sdkpath/sdkpath_test.go
@@ -15,13 +15,7 @@ func TestAndroidAPIPathAcceptsMinorVersionPlatforms(t *testing.T) {
 	t.Setenv("ANDROID_HOME", sdk)
 
 	for _, name := range []string{"android-36.1", "android-37.0"} {
-		platform := filepath.Join(sdk, "platforms", name)
-		if err := os.MkdirAll(platform, 0777); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(filepath.Join(platform, "android.jar"), nil, 0666); err != nil {
-			t.Fatal(err)
-		}
+		writeAndroidPlatform(t, sdk, name)
 	}
 
 	got, err := AndroidAPIPath(24)
@@ -31,5 +25,32 @@ func TestAndroidAPIPathAcceptsMinorVersionPlatforms(t *testing.T) {
 	want := filepath.Join(sdk, "platforms", "android-37.0")
 	if got != want {
 		t.Fatalf("AndroidAPIPath(24) = %q, want %q", got, want)
+	}
+}
+
+func TestAndroidAPIPathAcceptsMajorVersionPlatforms(t *testing.T) {
+	sdk := t.TempDir()
+	t.Setenv("ANDROID_HOME", sdk)
+	writeAndroidPlatform(t, sdk, "android-35")
+
+	got, err := AndroidAPIPath(24)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(sdk, "platforms", "android-35")
+	if got != want {
+		t.Fatalf("AndroidAPIPath(24) = %q, want %q", got, want)
+	}
+}
+
+func writeAndroidPlatform(t *testing.T, sdk, name string) {
+	t.Helper()
+
+	platform := filepath.Join(sdk, "platforms", name)
+	if err := os.MkdirAll(platform, 0777); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(platform, "android.jar"), nil, 0666); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/internal/sdkpath/sdkpath_test.go
+++ b/internal/sdkpath/sdkpath_test.go
@@ -10,54 +10,42 @@ import (
 	"testing"
 )
 
-func TestAndroidAPIPathAcceptsMinorVersionPlatforms(t *testing.T) {
-	sdk := t.TempDir()
-	t.Setenv("ANDROID_HOME", sdk)
-
-	for _, name := range []string{"android-36.1", "android-37.0"} {
-		writeAndroidPlatform(t, sdk, name)
-	}
-
-	got, err := AndroidAPIPath(24)
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := filepath.Join(sdk, "platforms", "android-37.0")
-	if got != want {
-		t.Fatalf("AndroidAPIPath(24) = %q, want %q", got, want)
-	}
-}
-
-func TestAndroidAPIPathAcceptsMajorVersionPlatforms(t *testing.T) {
-	sdk := t.TempDir()
-	t.Setenv("ANDROID_HOME", sdk)
-	writeAndroidPlatform(t, sdk, "android-35")
-
-	got, err := AndroidAPIPath(24)
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := filepath.Join(sdk, "platforms", "android-35")
-	if got != want {
-		t.Fatalf("AndroidAPIPath(24) = %q, want %q", got, want)
-	}
-}
-
-func TestAndroidAPIPathAcceptsMixedPlatformVersions(t *testing.T) {
+func TestAndroidAPIPath(t *testing.T) {
 	tests := []struct {
 		name      string
+		api       int
 		platforms []string
 		want      string
 	}{
 		{
+			name:      "minor-only versions",
+			api:       24,
+			platforms: []string{"android-36.1", "android-37.0"},
+			want:      "android-37.0",
+		},
+		{
+			name:      "major-only version",
+			api:       24,
+			platforms: []string{"android-35"},
+			want:      "android-35",
+		},
+		{
 			name:      "minor version is newer than major-only version",
+			api:       24,
 			platforms: []string{"android-35", "android-36", "android-36.1"},
 			want:      "android-36.1",
 		},
 		{
 			name:      "higher major-only version is newer than lower minor version",
+			api:       24,
 			platforms: []string{"android-36.1", "android-37"},
 			want:      "android-37",
+		},
+		{
+			name:      "minor version below requested API is ignored",
+			api:       37,
+			platforms: []string{"android-36.1", "android-37.0"},
+			want:      "android-37.0",
 		},
 	}
 
@@ -69,13 +57,13 @@ func TestAndroidAPIPathAcceptsMixedPlatformVersions(t *testing.T) {
 				writeAndroidPlatform(t, sdk, name)
 			}
 
-			got, err := AndroidAPIPath(24)
+			got, err := AndroidAPIPath(tt.api)
 			if err != nil {
 				t.Fatal(err)
 			}
 			want := filepath.Join(sdk, "platforms", tt.want)
 			if got != want {
-				t.Fatalf("AndroidAPIPath(24) = %q, want %q", got, want)
+				t.Fatalf("AndroidAPIPath(%d) = %q, want %q", tt.api, got, want)
 			}
 		})
 	}

--- a/internal/sdkpath/sdkpath_test.go
+++ b/internal/sdkpath/sdkpath_test.go
@@ -1,0 +1,35 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package sdkpath
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAndroidAPIPathAcceptsMinorVersionPlatforms(t *testing.T) {
+	sdk := t.TempDir()
+	t.Setenv("ANDROID_HOME", sdk)
+
+	for _, name := range []string{"android-36.1", "android-37.0"} {
+		platform := filepath.Join(sdk, "platforms", name)
+		if err := os.MkdirAll(platform, 0777); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(platform, "android.jar"), nil, 0666); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := AndroidAPIPath(24)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(sdk, "platforms", "android-37.0")
+	if got != want {
+		t.Fatalf("AndroidAPIPath(24) = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Android SDK platform directories can now include minor versions such as
android-36.1 and android-37.0. Parse platform names as major/minor
versions so AndroidAPIPath can find the latest platform satisfying the
requested minimum API level.

Add a focused internal/sdkpath test that creates a temporary SDK with
minor-version platforms and verifies that AndroidAPIPath selects the
highest matching platform.

Fixes golang/go#79606
